### PR TITLE
fix(React): build error due to TS version mismatch with dependency

### DIFF
--- a/packages/jmix-front-generator/src/generators/react-typescript/app/template/package.json
+++ b/packages/jmix-front-generator/src/generators/react-typescript/app/template/package.json
@@ -32,7 +32,7 @@
     "@types/react-dom": "^16.9.0",
     "@types/react-input-mask": "^2.0.5",
     "@types/react-router-dom": "^5.1.5",
-    "typescript": "~3.7.4"
+    "typescript": "~4.1.3"
   },
   "cubaPlatform": {
     "generator": "react-typescript"


### PR DESCRIPTION
affects: @haulmont/jmix-front-generator

TS in React client has been upgraded to ~4.1.3