### PR TITLE
refactor: replace isPropertyTypeSupported

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lerna": "lerna",
     "antora": "antora",
     "antora:gen": "antora --fetch",
-    "commit": "node_modules/commitizen/bin/git-cz",
+    "commit": "node node_modules/commitizen/bin/git-cz",
     "pack-given-client-libs": "node scripts/pack-given-client-libs.js",
     "pack-react-client-libs": "node scripts/pack-react-client-libs.js",
     "pack-react-native-client-libs": "node scripts/pack-react-native-client-libs.js",

--- a/packages/jmix-react-core/src/util/metadata.ts
+++ b/packages/jmix-react-core/src/util/metadata.ts
@@ -1,4 +1,4 @@
-import {EntityMessages, EnumInfo, MetaClassInfo, MetaPropertyInfo} from "@haulmont/jmix-rest";
+import {AttributeType, EntityMessages, EnumInfo, MetaClassInfo, MetaPropertyInfo} from "@haulmont/jmix-rest";
 
 export function getPropertyInfo(metadata: MetaClassInfo[], entityName: string, propertyName: string): MetaPropertyInfo | null {
     const metaClass = metadata.find(mci => mci.entityName === entityName);
@@ -58,6 +58,22 @@ export function getEnumCaption(enumValueName: string, propertyInfo: MetaProperty
  */
 export function getPropertyCaption(propertyName: string, entityName: string, messages: EntityMessages): string {
   return messages[entityName + '.' + propertyName];
+}
+
+export function isPropertyTypeSupported(propertyInfo: MetaPropertyInfo): boolean {
+  const supportedAttributeTypes: AttributeType[] = ['ENUM', 'ASSOCIATION', 'COMPOSITION'];
+  const supportedTypes: string[] = [
+    'string',
+    'uuid',
+    'int', 'double', 'decimal', 'long',
+    'date', 'time', 'dateTime',
+    'localDate', 'localTime', 'localDateTime',
+    'offsetTime', 'offsetDateTime',
+    'boolean'
+  ];
+
+  return supportedAttributeTypes.indexOf(propertyInfo.attributeType) > -1
+    || supportedTypes.indexOf(propertyInfo.type) > -1;
 }
 
 export function isFileProperty(propertyInfo: MetaPropertyInfo): boolean {

--- a/packages/jmix-react-ui/src/ui/table/DataTableHelpers.tsx
+++ b/packages/jmix-react-ui/src/ui/table/DataTableHelpers.tsx
@@ -15,7 +15,7 @@ import {
   DataTableCustomFilter as CustomFilter,
 } from './DataTableCustomFilter';
 import { toJS } from 'mobx';
-import { MainStore, getPropertyInfoNN, DataCollectionStore, getPropertyCaption } from '@haulmont/jmix-react-core';
+import { MainStore, getPropertyInfoNN, DataCollectionStore, getPropertyCaption, isPropertyTypeSupported } from '@haulmont/jmix-react-core';
 import {OperatorType, FilterValue} from "@haulmont/jmix-rest";
 import {setPagination} from "../paging/Paging";
 import {Key} from 'antd/es/table/interface';
@@ -476,20 +476,4 @@ export function isConditionsGroup(conditionOrConditionsGroup: Condition | Condit
  */
 export function isPreservedCondition(condition: Condition | ConditionsGroup, fields: string[]): boolean {
   return isConditionsGroup(condition) || fields.indexOf((condition as Condition).property) === -1;
-}
-
-export function isPropertyTypeSupported(propertyInfo: MetaPropertyInfo): boolean {
-  const supportedAttributeTypes: string[] = ['ENUM', 'ASSOCIATION', 'COMPOSITION'];
-  const supportedTypes: string[] = [
-    'string',
-    'uuid',
-    'int', 'double', 'decimal', 'long',
-    'date', 'time', 'dateTime',
-    'localDate', 'localTime', 'localDateTime',
-    'offsetTime', 'offsetDateTime',
-    'boolean'
-  ];
-
-  return supportedAttributeTypes.indexOf(propertyInfo.attributeType) > -1
-    || supportedTypes.indexOf(propertyInfo.type) > -1;
 }


### PR DESCRIPTION
affects: @haulmont/jmix-react-core, @haulmont/jmix-react-ui

replace isPropertyTypeSupported() to jmix-react-core/util/metadata