### PR TITLE
feat: added support of editing and removing entities with composite keys

### DIFF
--- a/packages/jmix-front-generator/src/generators/react-typescript/entity-cards/template/EntityCards.tsx.ejs
+++ b/packages/jmix-front-generator/src/generators/react-typescript/entity-cards/template/EntityCards.tsx.ejs
@@ -12,6 +12,7 @@ Paging,
 setPagination,
 Spinner
 } from "@haulmont/jmix-react-ui";
+import {getStringId} from "@haulmont/jmix-rest";
 import {action, IReactionDisposer, observable, reaction} from "mobx";
 import {PaginationConfig} from "antd/es/pagination";
 import {RouteComponentProps} from "react-router";
@@ -67,7 +68,7 @@ export class <%= className %> extends React.Component<Props> {
         {items.map(e =>
         <% /* todo null check of e.id will be removed after we strict id type in https://github.com/cuba-platform/frontend/issues/119 */ %>
         <Card title={e._instanceName}
-              key={e.id ? e.id : undefined}
+              key={e.id ? getStringId(e.id) : undefined}
               style={{marginBottom: '12px'}}>
             {this.fields.map(p =>
               <EntityProperty

--- a/packages/jmix-front-generator/src/generators/react-typescript/entity-management-hooks/template/Cards.tsx.ejs
+++ b/packages/jmix-front-generator/src/generators/react-typescript/entity-management-hooks/template/Cards.tsx.ejs
@@ -19,7 +19,7 @@ import {
 } from "@haulmont/jmix-react-ui";
 
 import {<%= entity.className %>} from "<%= relDirShift %><%= entity.path %>";
-import {SerializedEntity} from "@haulmont/jmix-rest";
+import {SerializedEntity, getStringId} from "@haulmont/jmix-rest";
 import {<%= className %>} from "./<%= className %>";
 import {
 FormattedMessage,
@@ -120,13 +120,13 @@ class <%= listComponentClass %>Component extends React.Component<Props> {
         {items.map(e =>
           <% /* todo null check of e.id will be removed after we strict id type in https://github.com/cuba-platform/frontend/issues/119 */ %>
           <Card title={e._instanceName}
-                key={e.id ? e.id : undefined}
+                key={e.id ? getStringId(e.id) : undefined}
                 style={{marginBottom: '12px'}}
                 actions={[
                   <DeleteOutlined
                         key='delete'
                         onClick={() => this.showDeletionDialog(e)}/>,
-                  <Link to={<%= className %>.PATH + '/' + e.id} key='edit'>
+                  <Link to={<%= className %>.PATH + '/' + getStringId(e.id!)} key='edit'>
                     <EditOutlined />
                   </Link>
                 ]}>

--- a/packages/jmix-front-generator/src/generators/react-typescript/entity-management-hooks/template/List.tsx.ejs
+++ b/packages/jmix-front-generator/src/generators/react-typescript/entity-management-hooks/template/List.tsx.ejs
@@ -9,7 +9,7 @@ import {collection, injectMainStore, MainStoreInjected, EntityPermAccessControl}
 import {EntityProperty, Paging, setPagination, Spinner} from "@haulmont/jmix-react-ui";
 
 import {<%= entity.className %>} from "<%= relDirShift %><%= entity.path %>";
-import {SerializedEntity} from "@haulmont/jmix-rest";
+import {SerializedEntity, getStringId} from "@haulmont/jmix-rest";
 import {<%= className %>} from "./<%= className %>";
 import {FormattedMessage, injectIntl, WrappedComponentProps} from 'react-intl';
 import {PaginationConfig} from "antd/es/pagination";
@@ -107,7 +107,7 @@ class <%= listComponentClass %>Component extends React.Component<Props> {
                     <DeleteOutlined
                           key='delete'
                           onClick={() => this.showDeletionDialog(item)}/>,
-                    <Link to={<%= className %>.PATH + '/' + item.id} key='edit'>
+                    <Link to={<%= className %>.PATH + '/' + getStringId(item.id!)} key='edit'>
                       <EditOutlined />
                     </Link>
                 ]}>

--- a/packages/jmix-front-generator/src/generators/react-typescript/entity-management-hooks/template/Table.tsx.ejs
+++ b/packages/jmix-front-generator/src/generators/react-typescript/entity-management-hooks/template/Table.tsx.ejs
@@ -9,7 +9,7 @@ import {collection, injectMainStore, MainStoreInjected, EntityPermAccessControl}
 import { DataTable, Spinner } from "@haulmont/jmix-react-ui";
 
 import {<%= entity.className %>} from "<%= relDirShift %><%= entity.path %>";
-import {SerializedEntity} from "@haulmont/jmix-rest";
+import {SerializedEntity, getStringId} from "@haulmont/jmix-rest";
 import {<%= className %>} from "./<%= className %>";
 import {FormattedMessage, injectIntl, WrappedComponentProps} from 'react-intl';
 
@@ -99,7 +99,7 @@ class <%= listComponentClass %>Component extends React.Component<MainStoreInject
 
   getRecordById(id: string): SerializedEntity<<%= entity.className %>> {
     const record: SerializedEntity<<%= entity.className %>> | undefined =
-    this.dataCollection.items.find(record => record.id === id);
+    this.dataCollection.items.find(record => getStringId(record.id!) === id);
 
     if (!record) {
       throw new Error('Cannot find entity with id ' + id);

--- a/packages/jmix-front-generator/src/generators/react-typescript/entity-management/template/Cards.tsx.ejs
+++ b/packages/jmix-front-generator/src/generators/react-typescript/entity-management/template/Cards.tsx.ejs
@@ -19,7 +19,7 @@ import {
 } from "@haulmont/jmix-react-ui";
 
 import {<%= entity.className %>} from "<%= relDirShift %><%= entity.path %>";
-import {SerializedEntity} from "@haulmont/jmix-rest";
+import {SerializedEntity, getStringId} from "@haulmont/jmix-rest";
 import {<%= className %>} from "./<%= className %>";
 import {
 FormattedMessage,
@@ -120,13 +120,13 @@ class <%= listComponentClass %>Component extends React.Component<Props> {
         {items.map(e =>
           <% /* todo null check of e.id will be removed after we strict id type in https://github.com/cuba-platform/frontend/issues/119 */ %>
           <Card title={e._instanceName}
-                key={e.id ? e.id : undefined}
+                key={e.id ? getStringId(e.id) : undefined}
                 style={{marginBottom: '12px'}}
                 actions={[
                   <DeleteOutlined
                         key='delete'
                         onClick={() => this.showDeletionDialog(e)}/>,
-                  <Link to={<%= className %>.PATH + '/' + e.id} key='edit'>
+                  <Link to={<%= className %>.PATH + '/' + getStringId(e.id!)} key='edit'>
                     <EditOutlined />
                   </Link>
                 ]}>

--- a/packages/jmix-front-generator/src/generators/react-typescript/entity-management/template/List.tsx.ejs
+++ b/packages/jmix-front-generator/src/generators/react-typescript/entity-management/template/List.tsx.ejs
@@ -9,7 +9,7 @@ import {collection, injectMainStore, MainStoreInjected, EntityPermAccessControl}
 import {EntityProperty, Paging, setPagination, Spinner} from "@haulmont/jmix-react-ui";
 
 import {<%= entity.className %>} from "<%= relDirShift %><%= entity.path %>";
-import {SerializedEntity} from "@haulmont/jmix-rest";
+import {SerializedEntity, getStringId} from "@haulmont/jmix-rest";
 import {<%= className %>} from "./<%= className %>";
 import {FormattedMessage, injectIntl, WrappedComponentProps} from 'react-intl';
 import {PaginationConfig} from "antd/es/pagination";
@@ -107,7 +107,7 @@ class <%= listComponentClass %>Component extends React.Component<Props> {
                     <DeleteOutlined
                           key='delete'
                           onClick={() => this.showDeletionDialog(item)}/>,
-                    <Link to={<%= className %>.PATH + '/' + item.id} key='edit'>
+                    <Link to={<%= className %>.PATH + '/' + getStringId(item.id!)} key='edit'>
                       <EditOutlined />
                     </Link>
                 ]}>

--- a/packages/jmix-front-generator/src/generators/react-typescript/entity-management/template/Table.tsx.ejs
+++ b/packages/jmix-front-generator/src/generators/react-typescript/entity-management/template/Table.tsx.ejs
@@ -9,7 +9,7 @@ import {collection, injectMainStore, MainStoreInjected, EntityPermAccessControl}
 import { DataTable, Spinner } from "@haulmont/jmix-react-ui";
 
 import {<%= entity.className %>} from "<%= relDirShift %><%= entity.path %>";
-import {SerializedEntity} from "@haulmont/jmix-rest";
+import {SerializedEntity, getStringId} from "@haulmont/jmix-rest";
 import {<%= className %>} from "./<%= className %>";
 import {FormattedMessage, injectIntl, WrappedComponentProps} from 'react-intl';
 
@@ -99,7 +99,7 @@ class <%= listComponentClass %>Component extends React.Component<MainStoreInject
 
   getRecordById(id: string): SerializedEntity<<%= entity.className %>> {
     const record: SerializedEntity<<%= entity.className %>> | undefined =
-    this.dataCollection.items.find(record => record.id === id);
+    this.dataCollection.items.find(record => getStringId(record.id!) === id);
 
     if (!record) {
       throw new Error('Cannot find entity with id ' + id);

--- a/packages/jmix-front-generator/src/generators/sdk/model/entities-generation.ts
+++ b/packages/jmix-front-generator/src/generators/sdk/model/entities-generation.ts
@@ -163,9 +163,8 @@ function createEntityClassMembers(ctx: ClassCreationContext): {
       if (attributeTypeInfo.importInfo) { importInfos.push(attributeTypeInfo.importInfo); }
 
         const idAttrName = ctx.entity.idAttributeName ?? 'id';
-        // REST API always sends ids as strings
-        const typeNode = entityAttr.name === idAttrName
-          ? ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
+        const typeNode = isIdAttr(entityAttr.name, idAttrName)
+          ? getIdTypeNode(entityAttr.mappingType)
           : createUnionWithNull(attributeTypeInfo.node);
 
         // REST API puts the id into the property "id" regardless of the actual attribute name.
@@ -287,3 +286,12 @@ function createImportInfo(importedEntity: ProjectEntityInfo, isCurrentEntityBase
   }
 }
 
+function isIdAttr(entityAttrName: string, idAttrName: string): boolean {
+  return entityAttrName === idAttrName;
+}
+
+function getIdTypeNode (idMappingTime: string): ts.TypeNode {
+  return idMappingTime =="EMBEDDED" 
+    ? ts.createKeywordTypeNode(ts.SyntaxKind.ObjectKeyword)
+    : ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+}

--- a/packages/jmix-front-generator/src/test/fixtures/react-client/src/app/entity-cards/MpgFavoriteCarCards.tsx
+++ b/packages/jmix-front-generator/src/test/fixtures/react-client/src/app/entity-cards/MpgFavoriteCarCards.tsx
@@ -17,6 +17,7 @@ import {
   setPagination,
   Spinner
 } from "@haulmont/jmix-react-ui";
+import { getStringId } from "@haulmont/jmix-rest";
 import { action, IReactionDisposer, observable, reaction } from "mobx";
 import { PaginationConfig } from "antd/es/pagination";
 import { RouteComponentProps } from "react-router";
@@ -61,7 +62,7 @@ export class MpgFavoriteCarCards extends React.Component<Props> {
         {items.map(e => (
           <Card
             title={e._instanceName}
-            key={e.id ? e.id : undefined}
+            key={e.id ? getStringId(e.id) : undefined}
             style={{ marginBottom: "12px" }}
           >
             {this.fields.map(p => (

--- a/packages/jmix-front-generator/src/test/fixtures/react-client/src/app/entity-management/CarCards.tsx
+++ b/packages/jmix-front-generator/src/test/fixtures/react-client/src/app/entity-management/CarCards.tsx
@@ -19,7 +19,7 @@ import {
 } from "@haulmont/jmix-react-ui";
 
 import { Car } from "jmix/entities/mpg$Car";
-import { SerializedEntity } from "@haulmont/jmix-rest";
+import { SerializedEntity, getStringId } from "@haulmont/jmix-rest";
 import { CarManagement } from "./CarManagement";
 import {
   FormattedMessage,
@@ -133,14 +133,17 @@ class CarCardsComponent extends React.Component<Props> {
         {items.map(e => (
           <Card
             title={e._instanceName}
-            key={e.id ? e.id : undefined}
+            key={e.id ? getStringId(e.id) : undefined}
             style={{ marginBottom: "12px" }}
             actions={[
               <DeleteOutlined
                 key="delete"
                 onClick={() => this.showDeletionDialog(e)}
               />,
-              <Link to={CarManagement.PATH + "/" + e.id} key="edit">
+              <Link
+                to={CarManagement.PATH + "/" + getStringId(e.id!)}
+                key="edit"
+              >
                 <EditOutlined />
               </Link>
             ]}

--- a/packages/jmix-front-generator/src/test/fixtures/react-client/src/app/entity-management/CarList.tsx
+++ b/packages/jmix-front-generator/src/test/fixtures/react-client/src/app/entity-management/CarList.tsx
@@ -19,7 +19,7 @@ import {
 } from "@haulmont/jmix-react-ui";
 
 import { Car } from "jmix/entities/mpg$Car";
-import { SerializedEntity } from "@haulmont/jmix-rest";
+import { SerializedEntity, getStringId } from "@haulmont/jmix-rest";
 import { CarManagement2 } from "./CarManagement2";
 import {
   FormattedMessage,
@@ -137,7 +137,10 @@ class CarListComponent extends React.Component<Props> {
                   key="delete"
                   onClick={() => this.showDeletionDialog(item)}
                 />,
-                <Link to={CarManagement2.PATH + "/" + item.id} key="edit">
+                <Link
+                  to={CarManagement2.PATH + "/" + getStringId(item.id!)}
+                  key="edit"
+                >
                   <EditOutlined />
                 </Link>
               ]}

--- a/packages/jmix-front-generator/src/test/fixtures/react-client/src/app/entity-management/CarTable.tsx
+++ b/packages/jmix-front-generator/src/test/fixtures/react-client/src/app/entity-management/CarTable.tsx
@@ -14,7 +14,7 @@ import {
 import { DataTable, Spinner } from "@haulmont/jmix-react-ui";
 
 import { Car } from "jmix/entities/mpg$Car";
-import { SerializedEntity } from "@haulmont/jmix-rest";
+import { SerializedEntity, getStringId } from "@haulmont/jmix-rest";
 import { CarManagement3 } from "./CarManagement3";
 import {
   FormattedMessage,
@@ -136,7 +136,9 @@ class CarTableComponent extends React.Component<
   getRecordById(id: string): SerializedEntity<Car> {
     const record:
       | SerializedEntity<Car>
-      | undefined = this.dataCollection.items.find(record => record.id === id);
+      | undefined = this.dataCollection.items.find(
+      record => getStringId(record.id!) === id
+    );
 
     if (!record) {
       throw new Error("Cannot find entity with id " + id);

--- a/packages/jmix-front-generator/src/test/fixtures/react-client/src/app/entity-management/CarTableLowCase.tsx
+++ b/packages/jmix-front-generator/src/test/fixtures/react-client/src/app/entity-management/CarTableLowCase.tsx
@@ -14,7 +14,7 @@ import {
 import { DataTable, Spinner } from "@haulmont/jmix-react-ui";
 
 import { Car } from "jmix/entities/mpg$Car";
-import { SerializedEntity } from "@haulmont/jmix-rest";
+import { SerializedEntity, getStringId } from "@haulmont/jmix-rest";
 import { CarManagementLowCase } from "./CarManagementLowCase";
 import {
   FormattedMessage,
@@ -140,7 +140,9 @@ class CarTableLowCaseComponent extends React.Component<
   getRecordById(id: string): SerializedEntity<Car> {
     const record:
       | SerializedEntity<Car>
-      | undefined = this.dataCollection.items.find(record => record.id === id);
+      | undefined = this.dataCollection.items.find(
+      record => getStringId(record.id!) === id
+    );
 
     if (!record) {
       throw new Error("Cannot find entity with id " + id);

--- a/packages/jmix-front-generator/src/test/fixtures/react-client/src/app/entity-management/StringIdMgtTableBrowse.tsx
+++ b/packages/jmix-front-generator/src/test/fixtures/react-client/src/app/entity-management/StringIdMgtTableBrowse.tsx
@@ -14,7 +14,7 @@ import {
 import { DataTable, Spinner } from "@haulmont/jmix-react-ui";
 
 import { StringIdTestEntity } from "jmix/entities/scr_StringIdTestEntity";
-import { SerializedEntity } from "@haulmont/jmix-rest";
+import { SerializedEntity, getStringId } from "@haulmont/jmix-rest";
 import { StringIdMgtTableManagement } from "./StringIdMgtTableManagement";
 import {
   FormattedMessage,
@@ -127,7 +127,9 @@ class StringIdMgtTableBrowseComponent extends React.Component<
   getRecordById(id: string): SerializedEntity<StringIdTestEntity> {
     const record:
       | SerializedEntity<StringIdTestEntity>
-      | undefined = this.dataCollection.items.find(record => record.id === id);
+      | undefined = this.dataCollection.items.find(
+      record => getStringId(record.id!) === id
+    );
 
     if (!record) {
       throw new Error("Cannot find entity with id " + id);

--- a/packages/jmix-react-core/src/data/Instance.tsx
+++ b/packages/jmix-react-core/src/data/Instance.tsx
@@ -1,6 +1,11 @@
 import {action, computed, observable, reaction, runInAction, toJS} from "mobx";
 import {
-  PredefinedView, SerializedEntityProps, TemporalPropertyType, MetaClassInfo, CommitMode
+  PredefinedView, 
+  SerializedEntityProps, 
+  TemporalPropertyType, 
+  MetaClassInfo, 
+  CommitMode,
+  getStringId
 } from "@haulmont/jmix-rest";
 import {inject, observer} from "mobx-react";
 import { IReactComponent } from "mobx-react/dist/types/IReactComponent";
@@ -431,7 +436,7 @@ export function instanceItemToFormFields<T>(
 
       const entityList = value as unknown as WithId[];
       fields[key] = entityList.reduce<string[]>((accumulator, nextEntity) => {
-        accumulator.push(nextEntity.id!);
+        accumulator.push(getStringId(nextEntity.id!));
         return accumulator;
       }, []);
       return;

--- a/packages/jmix-react-core/src/util/metadata.ts
+++ b/packages/jmix-react-core/src/util/metadata.ts
@@ -207,6 +207,6 @@ export function isOneToManyComposition(propertyInfo: MetaPropertyInfo): boolean 
   return isComposition(propertyInfo) && isOneToManyRelation(propertyInfo);
 }
 
-export type WithId = {id?: string};
+export type WithId = {id?: string | object};
 
 export type WithName = {name?: string};

--- a/packages/jmix-react-ui/src/ui/EntitySelectField.tsx
+++ b/packages/jmix-react-ui/src/ui/EntitySelectField.tsx
@@ -2,7 +2,7 @@ import {observer} from "mobx-react";
 import {Select} from "antd";
 import * as React from "react";
 import { DataCollectionStore, WithId } from "@haulmont/jmix-react-core";
-
+import {getStringId} from "@haulmont/jmix-rest";
 export interface EntitySelectFieldProps {
   optionsContainer?: DataCollectionStore<WithId>,
   allowClear?: boolean,
@@ -13,7 +13,7 @@ export const EntitySelectField = observer((props: EntitySelectFieldProps) => {
   return (
     <Select {...rest} loading={optionsContainer && optionsContainer.status === "LOADING"} >
       {optionsContainer && optionsContainer.items.filter(e => e.id != null).map(entity =>
-        <Select.Option value={entity.id!} key={entity.id}>
+        <Select.Option value={getStringId(entity.id!)} key={getStringId(entity.id!)}>
           {entity._instanceName}
         </Select.Option>)
       }

--- a/packages/jmix-react-ui/src/ui/table/DataTable.tsx
+++ b/packages/jmix-react-ui/src/ui/table/DataTable.tsx
@@ -14,7 +14,7 @@ import {
   handleTableChange,
   isPreservedCondition
 } from './DataTableHelpers';
-import {Condition, ConditionsGroup, EntityAttrPermissionValue, SerializedEntity} from "@haulmont/jmix-rest";
+import {Condition, ConditionsGroup, EntityAttrPermissionValue, SerializedEntity, getStringId} from "@haulmont/jmix-rest";
 import {
   MainStoreInjected,
   DataCollectionStore,
@@ -520,7 +520,7 @@ class DataTableComponent<E extends object> extends React.Component<DataTableProp
   }
 
   constructRowKey(record: E & WithId): string {
-    return record.id!;
+    return getStringId(record.id!);
   }
 
 }

--- a/packages/jmix-react-ui/src/ui/table/DataTableCustomFilter.tsx
+++ b/packages/jmix-react-ui/src/ui/table/DataTableCustomFilter.tsx
@@ -3,7 +3,7 @@ import { Form } from 'antd';
 import { Button, DatePicker, Divider, Input, message, Select, Spin, TimePicker } from 'antd';
 import {FilterDropdownProps} from 'antd/es/table/interface';
 import {observer} from 'mobx-react';
-import {MetaClassInfo, MetaPropertyInfo, NumericPropertyType, OperatorType, PropertyType} from '@haulmont/jmix-rest';
+import {MetaClassInfo, MetaPropertyInfo, NumericPropertyType, OperatorType, PropertyType, getStringId} from '@haulmont/jmix-rest';
 import {action, computed, observable} from 'mobx';
 import {Moment} from 'moment';
 import {DataTableListEditor} from './DataTableListEditor';
@@ -122,7 +122,7 @@ class DataTableCustomFilterComponent<E extends WithId>
             resp.forEach((instance) => {
               this.nestedEntityOptions.push({
                 caption: instance._instanceName || '',
-                value: instance.id
+                value: getStringId(instance.id!)
               });
             });
             this.loading = false;

--- a/packages/jmix-rest/src/jmix.ts
+++ b/packages/jmix-rest/src/jmix.ts
@@ -11,7 +11,7 @@ import {
 } from './model';
 import {DefaultStorage} from "./storage";
 import {EntityFilter} from "./filter";
-import {base64encode, encodeGetParams, matchesVersion} from "./util";
+import {base64encode, encodeGetParams, matchesVersion, getStringId} from "./util";
 import { restEventEmitter } from './event_emitter';
 
 export * from './model';
@@ -19,6 +19,7 @@ export * from './storage';
 export * from './filter';
 export * from './security';
 export * from './event_emitter';
+export * from './util';
 
 const apps: JmixRestConnection[] = [];
 
@@ -241,25 +242,25 @@ export class JmixRestConnection {
 
   public loadEntity<T>(
     entityName: string,
-    id,
+    id : string | object,
     options?: { view?: string },
     fetchOptions?: FetchOptions
   ): Promise<SerializedEntity<T>> {
-    return this.fetch('GET', 'entities/' + entityName + '/' + id, options, {handleAs: 'json', ...fetchOptions});
+    return this.fetch('GET', 'entities/' + entityName + '/' + getStringId(id), options, {handleAs: 'json', ...fetchOptions});
   }
 
-  public deleteEntity(entityName: string, id, fetchOptions?: FetchOptions): Promise<void> {
-    return this.fetch('DELETE', 'entities/' + entityName + '/' + id, null, fetchOptions);
+  public deleteEntity(entityName: string, id: string | object, fetchOptions?: FetchOptions): Promise<void> {
+    return this.fetch('DELETE', 'entities/' + entityName + '/' + getStringId(id), null, fetchOptions);
   }
 
-  public commitEntity<T extends {id?: string}>(
+  public commitEntity<T extends {id?: string | object}>(
     entityName: string,
     entity: T,
     fetchOptions?: FetchOptions
   ): Promise<Partial<T>> {
     const {commitMode} = fetchOptions ?? {};
     if (commitMode === 'edit' || (commitMode == null && entity.id != null)) {
-      return this.fetch('PUT', 'entities/' + entityName + '/' + entity.id, JSON.stringify(entity),
+      return this.fetch('PUT', 'entities/' + entityName + '/' + getStringId(entity.id), JSON.stringify(entity),
         {handleAs: 'json', ...fetchOptions});
     } else {
       return this.fetch('POST', 'entities/' + entityName, JSON.stringify(entity),

--- a/packages/jmix-rest/src/util.ts
+++ b/packages/jmix-rest/src/util.ts
@@ -79,3 +79,7 @@ function serialize(rawParam): string {
   }
   return rawParam;
 }
+
+export function getStringId(id: string | object) : string {
+  return typeof id === "object" ? base64encode(JSON.stringify(id)) : id;
+}

--- a/packages/jmix-rest/test/utlil.spec.js
+++ b/packages/jmix-rest/test/utlil.spec.js
@@ -54,5 +54,15 @@ describe('util', function() {
     })
   });
 
+  describe('.getStringId()', function() {
+    const stringId = 'tested id';
+    const objId = {testFld: "tested id"};
+    it ('return source id, if it has string type', function() {
+      assert.equal(util.getStringId(stringId), stringId);
+    });
+    it ('return converted id, if it has object type', function() {
+      assert.equal(util.getStringId(objId), "eyJ0ZXN0RmxkIjoidGVzdGVkIGlkIn0=");
+    });
+  });
 
 });


### PR DESCRIPTION
affects: @haulmont/jmix-front-generator, @haulmont/jmix-react-core, @haulmont/jmix-react-ui,
@haulmont/jmix-rest

BREAKING CHANGE:
added support of editing and removing entities with composite keys