### PR TITLE
fix: entity management graphql template: excessive parameters

### DIFF
--- a/packages/jmix-front-generator/src/generators/react-typescript/entity-management-graphql-hooks/answers.ts
+++ b/packages/jmix-front-generator/src/generators/react-typescript/entity-management-graphql-hooks/answers.ts
@@ -28,8 +28,7 @@ export interface EntityManagementAnswers extends StringIdAnswers {
 
 export const allQuestions: StudioTemplateProperty[] = [
   ...commonEntityManagementQuestions,
-  ...displayAttributesQuestions, // TODO merge with commonEntityManagementQuestions once REST API is removed
-  ...stringIdQuestions
+  ...displayAttributesQuestions // TODO merge with commonEntityManagementQuestions once REST API is removed
 ];
 
 export const getAnswersFromPrompt = async (


### PR DESCRIPTION

affects: @haulmont/jmix-front-generator