### PR TITLE
fix: do not send read-only attributes in mutations #297

### DIFF
--- a/example-react-app/src/app/datatypes-test-browser-cards/DatatypesTestBrowserCards.tsx
+++ b/example-react-app/src/app/datatypes-test-browser-cards/DatatypesTestBrowserCards.tsx
@@ -113,6 +113,7 @@ const SCR_DATATYPESTESTENTITY_LIST = gql`
         id
         _instanceName
       }
+      readOnlyStringAttr
       name
     }
   }

--- a/example-react-app/src/app/datatypes-test-browser-list/DatatypesTestBrowserList.tsx
+++ b/example-react-app/src/app/datatypes-test-browser-list/DatatypesTestBrowserList.tsx
@@ -112,6 +112,7 @@ const SCR_DATATYPESTESTENTITY_LIST = gql`
         id
         _instanceName
       }
+      readOnlyStringAttr
       name
     }
   }

--- a/example-react-app/src/app/datatypes-test-browser-table/DatatypesTestBrowserTable.tsx
+++ b/example-react-app/src/app/datatypes-test-browser-table/DatatypesTestBrowserTable.tsx
@@ -103,6 +103,7 @@ const SCR_DATATYPESTESTENTITY_LIST = gql`
         id
         _instanceName
       }
+      readOnlyStringAttr
       name
     }
 
@@ -273,6 +274,7 @@ const DatatypesTestBrowserTable = observer(
           "compositionO2Oattr",
           "intIdentityIdTestEntityAssociationO2OAttr",
           "datatypesTestEntity3",
+          "readOnlyStringAttr",
           "name"
         ]}
         onRowSelectionChange={handleSelectionChange}

--- a/example-react-app/src/app/datatypes-test-cards/DatatypesTestCards.tsx
+++ b/example-react-app/src/app/datatypes-test-cards/DatatypesTestCards.tsx
@@ -99,6 +99,7 @@ const SCR_DATATYPESTESTENTITY_LIST = gql`
         id
         _instanceName
       }
+      readOnlyStringAttr
       name
     }
   }

--- a/example-react-app/src/app/datatypes-test-editor/DatatypesTestEditor.tsx
+++ b/example-react-app/src/app/datatypes-test-editor/DatatypesTestEditor.tsx
@@ -94,6 +94,7 @@ const LOAD_SCR_DATATYPESTESTENTITY = gql`
         id
         _instanceName
       }
+      readOnlyStringAttr
       name
     }
 
@@ -392,6 +393,15 @@ const DatatypesTestEditor = observer(
             associationOptions={relationOptions?.get(
               "scr_DatatypesTestEntity3"
             )}
+            formItemProps={{
+              style: { marginBottom: "12px" }
+            }}
+          />
+
+          <Field
+            entityName={ENTITY_NAME}
+            propertyName="readOnlyStringAttr"
+            disabled={true}
             formItemProps={{
               style: { marginBottom: "12px" }
             }}

--- a/packages/jmix-react-ui/src/formatters/jmixFront_to_jmixGraphQL.ts
+++ b/packages/jmix-react-ui/src/formatters/jmixFront_to_jmixGraphQL.ts
@@ -20,12 +20,18 @@ export function jmixFront_to_jmixGraphQL(
   Object.entries(item).forEach(([attributeName, value]) => {
     const propInfo = getPropertyInfo(metadata.entities, entityName, attributeName);
 
+    if (propInfo == null) {
+      // There won't be property info e.g. for `_instanceName`.
+      // Normally we would expect everything that is a part of a valid input object to have property info.
+      return;
+    }
+
     // Recursively traverse compositions
-    if (propInfo != null && isOneToOneComposition(propInfo) && value != null) {
+    if (isOneToOneComposition(propInfo) && value != null) {
       result[attributeName] = jmixFront_to_jmixGraphQL(value, propInfo.type, metadata);
       return;
     }
-    if (propInfo != null && isOneToManyComposition(propInfo) && value != null) {
+    if (isOneToManyComposition(propInfo) && value != null) {
       result[attributeName] = value.map((e: Record<string, any>) => jmixFront_to_jmixGraphQL(e, propInfo.type, metadata));
       return;
     }
@@ -40,6 +46,11 @@ export function jmixFront_to_jmixGraphQL(
       if (!isTempId(value)) {
         result.id = value;
       }
+      return;
+    }
+
+    // Strip read-only fields
+    if (propInfo.readOnly) {
       return;
     }
 

--- a/scripts/model/graphql/datatypesTestEntity.js
+++ b/scripts/model/graphql/datatypesTestEntity.js
@@ -68,11 +68,10 @@ const datatypesQuery = `
     id
     _instanceName
   }
+  readOnlyStringAttr
   name
 }
 `;
-
-// readOnlyStringAttr TODO https://github.com/Haulmont/jmix-graphql/issues/85
 
 // stringIdTestEntityAssociationO2O {
 //   id


### PR DESCRIPTION
affects: @haulmont/jmix-react-ui