### PR TITLE
fix: support bean validation for child entities #390

### DIFF
--- a/example-react-app/package.json
+++ b/example-react-app/package.json
@@ -4,8 +4,8 @@
   "dependencies": {
     "@ant-design/icons": "^4.0.0",
     "@apollo/client": "^3.3.15",
-    "@haulmont/jmix-react-core": "file:../packages/jmix-react-core/haulmont-jmix-react-core-1.0.0-next.21.tgz",
-    "@haulmont/jmix-react-ui": "file:../packages/jmix-react-ui/haulmont-jmix-react-ui-1.0.0-next.21.tgz",
+    "@haulmont/jmix-react-core": "file:../packages/jmix-react-core/haulmont-jmix-react-core-1.0.0-next.22.tgz",
+    "@haulmont/jmix-react-ui": "file:../packages/jmix-react-ui/haulmont-jmix-react-ui-1.0.0-next.22.tgz",
     "@haulmont/jmix-rest": "file:../packages/jmix-rest/haulmont-jmix-rest-1.0.0-next.20.tgz",
     "@haulmont/react-ide-toolbox": "file:../packages/react-ide-toolbox/haulmont-react-ide-toolbox-1.0.0-next.20.tgz",
     "@haulmont/react-scripts": "^4.0.2-alpha.8",

--- a/example-react-app/src/i18n/en.json
+++ b/example-react-app/src/i18n/en.json
@@ -129,6 +129,7 @@
   "jmix.nestedEntityField.andXMore": " and {quantity} more",
   "jmix.nestedEntityField.delete.areYouSure": "Are you sure you want to delete the nested entity?",
   "jmix.nestedEntitiesTableField.delete.areYouSure": "Are you sure you want to delete the nested entity?",
+  "jmix.form.validation.childError": "Validation error in child entity",
   "cubaRest.error.serverNotResponded": "Server not responded",
   "cubaRest.error.serverError": "Internal server error",
   "cubaRest.error.badRequest": "Bad request",

--- a/example-react-app/src/i18n/ru.json
+++ b/example-react-app/src/i18n/ru.json
@@ -77,6 +77,7 @@
   "jmix.nestedEntityField.andXMore": " и ещё {quantity}",
   "jmix.nestedEntityField.delete.areYouSure": "Удалить вложенную сущность?",
   "jmix.nestedEntitiesTableField.delete.areYouSure": "Удалить вложенную сущность?",
+  "jmix.form.validation.childError": "Ошибка валидации во вложенной сущности",
   "cubaRest.error.serverNotResponded": "Сервер не отвечает",
   "cubaRest.error.serverError": "Ошибка на стороне сервера",
   "cubaRest.error.badRequest": "Запрос сформирован неправильно",

--- a/packages/jmix-front-generator/src/generators/react-typescript/app/template/i18n-message-packs/en.json
+++ b/packages/jmix-front-generator/src/generators/react-typescript/app/template/i18n-message-packs/en.json
@@ -83,6 +83,8 @@
 
   "jmix.nestedEntitiesTableField.delete.areYouSure": "Are you sure you want to delete the nested entity?",
 
+  "jmix.form.validation.childError": "Validation error in child entity",
+
   "cubaRest.error.serverNotResponded": "Server not responded",
   "cubaRest.error.serverError": "Internal server error",
   "cubaRest.error.badRequest": "Bad request",

--- a/packages/jmix-front-generator/src/generators/react-typescript/app/template/i18n-message-packs/fr.json
+++ b/packages/jmix-front-generator/src/generators/react-typescript/app/template/i18n-message-packs/fr.json
@@ -83,6 +83,8 @@
   
     "jmix.nestedEntitiesTableField.delete.areYouSure": "Êtes-vous sûr de vouloir effacer l'entité imbriqué?",
 
+    "jmix.form.validation.childError": "jmix.form.validation.childError [TRANSLATION NOT AVAILABLE]",
+
     "cubaRest.error.serverNotResponded": "cubaRest.error.serverNotResponded [TRANSLATION NOT AVAILABLE]",
     "cubaRest.error.serverError": "cubaRest.error.serverError [TRANSLATION NOT AVAILABLE]",
     "cubaRest.error.badRequest": "cubaRest.error.badRequest [TRANSLATION NOT AVAILABLE]",

--- a/packages/jmix-front-generator/src/generators/react-typescript/app/template/i18n-message-packs/ru.json
+++ b/packages/jmix-front-generator/src/generators/react-typescript/app/template/i18n-message-packs/ru.json
@@ -83,6 +83,8 @@
 
   "jmix.nestedEntitiesTableField.delete.areYouSure": "Удалить вложенную сущность?",
 
+  "jmix.form.validation.childError": "Ошибка валидации во вложенной сущности",
+
   "cubaRest.error.serverNotResponded": "Сервер не отвечает",
   "cubaRest.error.serverError": "Ошибка на стороне сервера",
   "cubaRest.error.badRequest": "Запрос сформирован неправильно",

--- a/packages/jmix-front-generator/src/generators/react-typescript/app/template/i18n-message-packs/zh-cn.json
+++ b/packages/jmix-front-generator/src/generators/react-typescript/app/template/i18n-message-packs/zh-cn.json
@@ -84,6 +84,8 @@
 
   "jmix.nestedEntitiesTableField.delete.areYouSure": "确定要删除子实体？",
 
+  "jmix.form.validation.childError": "jmix.form.validation.childError [TRANSLATION NOT AVAILABLE]",
+
   "cubaRest.error.serverNotResponded": "cubaRest.error.serverNotResponded [TRANSLATION NOT AVAILABLE]",
   "cubaRest.error.serverError": "cubaRest.error.serverError [TRANSLATION NOT AVAILABLE]",
   "cubaRest.error.badRequest": "cubaRest.error.badRequest [TRANSLATION NOT AVAILABLE]",

--- a/packages/jmix-react-ui/src/crud/editor/validation/useAntdFormValidation.ts
+++ b/packages/jmix-react-ui/src/crud/editor/validation/useAntdFormValidation.ts
@@ -1,14 +1,22 @@
 import { FormInstance } from "antd";
 import {JmixServerValidationErrors} from "../../../common/JmixServerValidationErrors";
 import {FieldData} from "rc-field-form/es/interface";
+import {IntlShape, useIntl } from "react-intl";
 
 export function useAntdFormValidation(form: FormInstance, errorInfo?: JmixServerValidationErrors) {
+  const intl = useIntl();
+
   if (errorInfo == null || errorInfo?.fieldErrors == null) {
     return;
   }
 
   const fieldsPartial: FieldData[] = [];
   errorInfo?.fieldErrors.forEach((messages: string[], path: string) => {
+    if (path.includes('.')) {
+      addChildEntityError(fieldsPartial, path, intl);
+      return;
+    }
+
     fieldsPartial.push({
       name: path,
       errors: messages
@@ -17,4 +25,35 @@ export function useAntdFormValidation(form: FormInstance, errorInfo?: JmixServer
 
   // Put the error messages into the form
   form.setFields(fieldsPartial);
+}
+
+/**
+ * Adds "Validation error in child entity" message on a Composition field
+ * if it isn't already there.
+ *
+ * @param fieldsPartial
+ * @param path
+ * @param intl
+ */
+function addChildEntityError(fieldsPartial: FieldData[], path: string, intl: IntlShape) {
+  const childErrorMessage = intl.formatMessage({id: 'jmix.form.validation.childError'});
+
+  const fieldName = path.split('.')[0];
+
+  if (!fieldsPartial.some(f => f.name === fieldName)) {
+    fieldsPartial.push({
+      name: fieldName,
+      errors: []
+    })
+  }
+
+  const fieldIndex = fieldsPartial.findIndex(f => f.name === fieldName);
+
+  if (fieldsPartial[fieldIndex].errors == null) {
+    fieldsPartial[fieldIndex].errors = [];
+  }
+
+  if (!fieldsPartial[fieldIndex].errors!.some(e => e === childErrorMessage)) {
+    fieldsPartial[fieldIndex].errors!.push(childErrorMessage);
+  }
 }

--- a/packages/jmix-react-ui/src/ui/form/CompositionFields.less
+++ b/packages/jmix-react-ui/src/ui/form/CompositionFields.less
@@ -1,3 +1,10 @@
+@import 'antd/es/style/themes/default';
+
 .jmix-composition-field-upsert-btn {
+  padding-right: 0;
   padding-left: 0;
+}
+
+.ant-form-item-has-error .jmix-composition-field {
+  border: solid 1px @error-color;
 }

--- a/packages/jmix-react-ui/src/ui/form/CompositionO2MField.tsx
+++ b/packages/jmix-react-ui/src/ui/form/CompositionO2MField.tsx
@@ -42,7 +42,7 @@ export const CompositionO2MField = observer((props: CompositionO2MFieldProps) =>
   return (
     <Button type='link'
             onClick={handleClick}
-            className='jmix-composition-field-upsert-btn'
+            className='jmix-composition-field jmix-composition-field-upsert-btn'
     >
       <BtnTitle value={value} />
     </Button>

--- a/packages/jmix-react-ui/src/ui/form/CompositionO2OField.less
+++ b/packages/jmix-react-ui/src/ui/form/CompositionO2OField.less
@@ -1,3 +1,0 @@
-.jmix-composition-field-upsert-btn {
-  padding-left: 0;
-}

--- a/packages/jmix-react-ui/src/ui/form/CompositionO2OField.tsx
+++ b/packages/jmix-react-ui/src/ui/form/CompositionO2OField.tsx
@@ -73,7 +73,7 @@ export const CompositionO2OField = observer((props: CompositionO2OFieldProps) =>
   );
 
   return (
-    <span>
+    <span className='jmix-composition-field'>
       <Button type='link'
               onClick={handleUpsertBtnClick}
               className='jmix-composition-field-upsert-btn'


### PR DESCRIPTION
    affects: @haulmont/jmix-front-generator, @haulmont/jmix-react-ui