### PR TITLE
fix: correct menuItems captions after locale changing #418

### DIFF
--- a/packages/jmix-react-ui/src/ui/menu/menu-item/MenuItem.tsx
+++ b/packages/jmix-react-ui/src/ui/menu/menu-item/MenuItem.tsx
@@ -12,11 +12,11 @@ interface Props extends MenuItemProps {
 
 export const MenuItem: React.FC<Props> = ({ screenId, caption, title, onClick, children, ...menuItemProps }: Props) => {
   const [currentMenuItem, setCurrentMenuItem] = useState<RouteItem | SubMenu | null>(null);
-  const {formatMessage} = useIntl();
+  const {formatMessage, locale} = useIntl();
 
   const formattedCaption = useMemo(() => {
     return formatMessage({id: caption, defaultMessage: caption})
-  }, [caption])
+  }, [caption, locale]);
 
   useEffect(() => {
     const menuItem: any = screenId

--- a/packages/jmix-react-ui/src/ui/menu/sub-menu-item/SubMenuItem.tsx
+++ b/packages/jmix-react-ui/src/ui/menu/sub-menu-item/SubMenuItem.tsx
@@ -7,11 +7,11 @@ interface Props extends SubMenuProps {
 }
 
 export const SubMenuItem: React.FC<Props> = ({caption, ...subMenuItemProps}: Props) => {
-  const {formatMessage} = useIntl();
+  const {formatMessage, locale} = useIntl();
 
   const formattedCaption = useMemo(() => {
     return formatMessage({id: caption, defaultMessage: caption})
-  }, [caption])
+  }, [caption, locale]);
 
   return (
     <Menu.SubMenu 


### PR DESCRIPTION
affects: @haulmont/jmix-react-ui