### PR TITLE
fix: pagination doesn't change when deleting last item #391

### DIFF
--- a/packages/jmix-react-ui/src/crud/list/useEntityList.ts
+++ b/packages/jmix-react-ui/src/crud/list/useEntityList.ts
@@ -288,6 +288,14 @@ export function useEntityList<
 
   const goToParentScreen = useParentScreen(routingPath);
 
+  // If we have deleted the last item on page, and it's not the first page, we want to change pagination
+  if (items?.length === 0
+    && entityListState?.pagination?.current != null
+    && entityListState?.pagination?.current > 0
+  ) {
+    handlePaginationChange(entityListState?.pagination?.current - 1, entityListState?.pagination?.pageSize);
+  }
+
   return {
     items,
     count,


### PR DESCRIPTION
affects: @haulmont/jmix-react-ui