### PR TITLE
fix: get pagination params from URL #422

### DIFF
--- a/packages/jmix-react-ui/src/ui/Tabs/index.tsx
+++ b/packages/jmix-react-ui/src/ui/Tabs/index.tsx
@@ -67,7 +67,7 @@ const Content = observer((props: IContentProps) => {
 
 function checkRoute(item: RouteItem) {
   if (item.menuLink === window.location.pathname || (window.location.pathname + '/').indexOf(item.menuLink + '/') === 0) {
-    openScreenInTab(item.screenId, item.menuLink);
+    openScreenInTab(item.screenId, window.location.pathname + window.location.search);
   }
 }
 


### PR DESCRIPTION
affects: @haulmont/jmix-react-ui