### PR TITLE
fix: compilation of new project fails due to empty routing.ts #448

### DIFF
--- a/packages/jmix-front-generator/src/generators/react-typescript/app/template/src/routing.ts
+++ b/packages/jmix-front-generator/src/generators/react-typescript/app/template/src/routing.ts
@@ -1,0 +1,1 @@
+import { menuItems } from "@haulmont/jmix-react-ui";


### PR DESCRIPTION
affects: @haulmont/jmix-front-generator