### PR TITLE
fix: filter, sorting and pagination callbacks all fire simultaneously…

### DIFF
--- a/packages/jmix-react-ui/src/ui/table/DataTable.tsx
+++ b/packages/jmix-react-ui/src/ui/table/DataTable.tsx
@@ -2,7 +2,7 @@ import React, {ReactNode, ReactText} from 'react';
 import { FilterOutlined } from '@ant-design/icons';
 import { Button, message, Spin, Table } from 'antd';
 import {ColumnProps, TableProps} from 'antd/es/table';
-import {Key, RowSelectionType, SorterResult, TablePaginationConfig} from 'antd/es/table/interface';
+import {Key, RowSelectionType, SorterResult, TableCurrentDataSource, TablePaginationConfig} from 'antd/es/table/interface';
 import {
   action,
   computed,
@@ -343,7 +343,14 @@ class DataTableComponent<
     this.valuesByProperty.set(propertyName, value);
   };
 
-  onChange = (pagination: TablePaginationConfig, filters: Record<string, Array<Key | boolean> | null>, sorter: SorterResult<TEntity> | Array<SorterResult<TEntity>>): void => {
+  onChange = (
+    pagination: TablePaginationConfig,
+    filters: Record<string, Array<Key | boolean> | null>,
+    sorter: SorterResult<TEntity> | Array<SorterResult<TEntity>>,
+    extra: TableCurrentDataSource<TEntity>
+  ): void => {
+    const {action: tableAction} = extra;
+
     this.tableFilters = filters;
 
     const {fields} = this;
@@ -364,7 +371,8 @@ class DataTableComponent<
       fields,
       metadata,
       entityName,
-      onPaginationChange
+      onPaginationChange,
+      tableAction
     });
   };
 

--- a/packages/jmix-react-ui/src/ui/table/DataTableHelpers.tsx
+++ b/packages/jmix-react-ui/src/ui/table/DataTableHelpers.tsx
@@ -1,5 +1,5 @@
 import {ColumnProps, TablePaginationConfig} from 'antd/es/table';
-import {SorterResult, ColumnFilterItem, FilterDropdownProps} from 'antd/es/table/interface';
+import {SorterResult, ColumnFilterItem, FilterDropdownProps, TableAction} from 'antd/es/table/interface';
 import React, { ReactText } from 'react';
 import {DataTableCell} from './DataTableCell';
 import {
@@ -24,7 +24,8 @@ import {
   FilterChangeCallback,
   JmixEntityFilter,
   JmixSortOrder,
-  SortOrderChangeCallback
+  SortOrderChangeCallback,
+  assertNever
 } from '@haulmont/jmix-react-core';
 import {Key} from 'antd/es/table/interface';
 import { FormInstance } from 'antd/es/form';
@@ -447,6 +448,10 @@ export interface TableChangeShape<E> {
   fields: string[],
   metadata: Metadata;
   entityName: string;
+  /**
+   * What has triggered the callback: change in pagination, sorters or filters.
+   */
+  tableAction: TableAction;
 }
 
 /**
@@ -469,12 +474,23 @@ export function handleTableChange<E>(tableChange: TableChangeShape<E>): void {
     onPaginationChange,
     fields,
     metadata,
-    entityName
+    entityName,
+    tableAction
   } = tableChange;
 
-  setFilters(tableFilters, onFilterChange, entityName, fields, metadata, apiFilters);
-  setSorter(sorter, onSortOrderChange, defaultSortOrder);
-  onPaginationChange(pagination.current, pagination.pageSize);
+  switch (tableAction) {
+    case 'filter':
+      setFilters(tableFilters, onFilterChange, entityName, fields, metadata, apiFilters);
+      break;
+    case 'sort':
+      setSorter(sorter, onSortOrderChange, defaultSortOrder);
+      break;
+    case 'paginate':
+      onPaginationChange(pagination.current, pagination.pageSize);
+      break;
+    default:
+      assertNever('table action', tableAction);
+  }
 }
 
 // TODO docs


### PR DESCRIPTION
… #383

affects: @haulmont/jmix-react-ui