### PR TITLE
fix: entity list sends negative offset when there are no items

### DIFF
--- a/packages/jmix-react-ui/src/crud/list/useEntityList.ts
+++ b/packages/jmix-react-ui/src/crud/list/useEntityList.ts
@@ -291,7 +291,7 @@ export function useEntityList<
   // If we have deleted the last item on page, and it's not the first page, we want to change pagination
   if (items?.length === 0
     && entityListState?.pagination?.current != null
-    && entityListState?.pagination?.current > 0
+    && entityListState?.pagination?.current > 1
   ) {
     handlePaginationChange(entityListState?.pagination?.current - 1, entityListState?.pagination?.pageSize);
   }


### PR DESCRIPTION
affects: @haulmont/jmix-react-ui