### PR TITLE
fix: disable text wrap inside breadcrumb #416

### DIFF
--- a/packages/jmix-react-ui/src/ui/MultiScreen/styles.less
+++ b/packages/jmix-react-ui/src/ui/MultiScreen/styles.less
@@ -4,6 +4,7 @@
   overflow-x: auto;
 
   .jmix-multi-screen--breadcrumb {
+    white-space: nowrap;
     margin-right: 20px;
     position: relative;
     cursor: pointer;


### PR DESCRIPTION
affects: @haulmont/jmix-react-ui