### PR TITLE
fix: onRowSelectionChange is called twice on every click on the row #373

### DIFF
--- a/packages/jmix-react-ui/src/ui/table/DataTable.test.tsx
+++ b/packages/jmix-react-ui/src/ui/table/DataTable.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import {render, screen} from '@testing-library/react'
+import {create, ReactTestInstance} from 'react-test-renderer';
 import React from 'react';
 import {DataTable} from "./DataTable";
 import {IntlProvider} from "react-intl";
@@ -24,29 +24,70 @@ window.matchMedia = () => ({
 }) as any;
 
 describe('<DataTable>', () => {
-  it('renders', async () => {
-    render(
-      <Provider mainStore={mainStore}>
-        <IntlProvider locale='en'>
-          <DataTable loading={false}
-                     onFilterChange={noop}
-                     onSortOrderChange={noop}
-                     onPaginationChange={noop}
-                     entityName={'scr_Car'}
-                     columnDefinitions={[
-                       'manufacturer',
-                       'model'
-                     ]}
-                     items={[
-                       {manufacturer: 'AAA', model: '001', id: '1'},
-                       {manufacturer: 'BBB', model: '002', id: '2'},
-                     ]}
-                     count={2}
-          />
-        </IntlProvider>
-      </Provider>
-    );
-    const table = await screen.findByRole('table');
-    expect(table).toBeInTheDocument();
+  const dataTableTestRenderer = create(
+    <Provider mainStore={mainStore}>
+      <IntlProvider locale='en'>
+        <DataTable loading={false}
+                   onFilterChange={noop}
+                   onSortOrderChange={noop}
+                   onPaginationChange={noop}
+                   entityName={'scr_Car'}
+                   columnDefinitions={[
+                     'manufacturer',
+                     'model'
+                   ]}
+                   items={[
+                     {manufacturer: 'AAA', model: '001', id: '1'},
+                     {manufacturer: 'BBB', model: '002', id: '2'},
+                   ]}
+                   count={2}
+        />
+      </IntlProvider>
+    </Provider>
+  );
+
+  const dataTableTestInstance = dataTableTestRenderer.root;
+
+  const intlComponent = dataTableTestInstance.children[0] as ReactTestInstance;
+  const mainStoreComponent = intlComponent.children[0] as ReactTestInstance;
+  const metadataComponent = mainStoreComponent.children[0] as ReactTestInstance;
+  const observerComponent = metadataComponent.children[0] as ReactTestInstance;
+  const dataTableComponent = observerComponent.children[0] as ReactTestInstance;
+
+
+  it('renders',  () => {
+    expect(dataTableTestInstance).not.toBeNull();
   });
+
+  it('wrapper has a DataTable child that has a selectedRowKeys property', () => {
+    expect(dataTableComponent.instance.selectedRowKeys).not.toBeUndefined();
+  })
+
+  it('selectedRowKeys must be an empty array', () => {
+    expect(dataTableComponent.instance.selectedRowKeys).toBeInstanceOf(Array);
+    expect(dataTableComponent.instance.selectedRowKeys).toHaveLength(0);
+  })
+
+  it('DataTable.onRowSelectionChange must be called once after click on the row', async () => {
+    // Find the rows
+    const rows = dataTableComponent.findAllByProps({className: 'ant-table-row ant-table-row-level-0'})
+
+    expect(dataTableComponent.instance.disposers.length).toBeGreaterThanOrEqual(1);
+    const prevSelectedRowKeys = [...dataTableComponent.instance.selectedRowKeys];
+    expect(prevSelectedRowKeys).toHaveLength(0);
+
+    rows[0].props.onClick(new Event('click'))
+    const newSelectedRowKeys = dataTableComponent.instance.selectedRowKeys;
+    expect(prevSelectedRowKeys).not.toEqual(newSelectedRowKeys);
+    expect(newSelectedRowKeys).toHaveLength(1);
+  })
+
+  it('DataTable.items must be the same after click on the row (row selection)', () => {
+    const prevItems = dataTableComponent.instance.items;
+
+    const rows = dataTableComponent.findAllByProps({className: 'ant-table-row ant-table-row-level-0'});
+    rows[0].props.onClick(new Event('click'));
+
+    expect(dataTableComponent.instance.items === prevItems).toBe(true);
+  })
 });

--- a/packages/jmix-react-ui/src/ui/table/DataTable.tsx
+++ b/packages/jmix-react-ui/src/ui/table/DataTable.tsx
@@ -10,7 +10,7 @@ import {
   observable,
   reaction,
   toJS,
-  makeObservable,
+  makeObservable, comparer,
 } from 'mobx';
 import {observer} from 'mobx-react';
 import {CustomFilterInputValue} from './DataTableCustomFilter';
@@ -152,6 +152,7 @@ export interface ColumnDefinition<TEntity> {
    */
   columnProps: ColumnProps<TEntity>
 }
+
 class DataTableComponent<
   TEntity extends object = object
 > extends React.Component<DataTableProps<TEntity>, any> {
@@ -213,16 +214,10 @@ class DataTableComponent<
 
           const displayedRowKeys = items.map((item: EntityInstance<TEntity>) => this.constructRowKey(item));
 
-          const displayedSelectedKeys: string[] = [];
-
-          this.selectedRowKeys.forEach((selectedKey: string) => {
-            if (displayedRowKeys.indexOf(selectedKey) > -1) {
-              displayedSelectedKeys.push(selectedKey);
-            }
-          });
-
-          this.selectedRowKeys = displayedSelectedKeys;
+          this.selectedRowKeys = this.selectedRowKeys.filter(selectedKey => displayedRowKeys.indexOf(selectedKey) > -1);
         }
+      }, {
+        equals: comparer.structural
       }
     ));
 


### PR DESCRIPTION
[DataTable onRowSelectionChange event doesn't work correct](https://app.zenhub.com/workspaces/jmix-frontend-issues-5fe0992a4308f20011f1c913/issues/haulmont/jmix-frontend/373) #373 