### PR TITLE
refactor: remove non-null assertion operator from Screens and Tabs

### DIFF
--- a/packages/jmix-react-core/src/app/Screens.test.ts
+++ b/packages/jmix-react-core/src/app/Screens.test.ts
@@ -49,7 +49,7 @@ describe('Screens', () => {
     expect(screens.screens[0]).toEqual(screen1);
     expect(screens.screens[1]).toEqual(screen2);
     expect(screens.currentScreen).toEqual(screen2);
-    expect(screens.currentScreen.parent).toEqual(screen1);
+    expect(screens.currentScreen?.parent).toEqual(screen1);
   });
 
   describe('Screens.setActiveScreen()', () => {

--- a/packages/jmix-react-core/src/app/Screens.ts
+++ b/packages/jmix-react-core/src/app/Screens.ts
@@ -24,13 +24,13 @@ export interface MultiScreenItemParams {
  * Screens API
  */
 export class Screens {
-  props: IMultiScreenProps = null!;
+  props: IMultiScreenProps | undefined = undefined;
   currentRootPageData = {
     title: '',
     menuPath: '',
   };
   @observable.ref screens: IMultiScreenItem[] = [];
-  @observable.ref currentScreen: IMultiScreenItem = null!;
+  @observable.ref currentScreen: IMultiScreenItem | undefined = undefined;
 
   constructor() {
     makeObservable(this);
@@ -49,7 +49,7 @@ export class Screens {
   get content() {
     const {screens: screensList, currentScreen, props} = this;
     if (screensList.length === 0) {
-      return props.children;
+      return props?.children;
     }
 
     for (const screen of screensList) {
@@ -58,7 +58,7 @@ export class Screens {
       }
     }
 
-    return props.children;
+    return props?.children;
   }
 
   /**
@@ -84,7 +84,7 @@ export class Screens {
    */
   closeAll = action(() => {
     this.screens = [];
-    this.currentScreen = null!;
+    this.currentScreen = undefined;
   });
 
   /**

--- a/packages/jmix-react-core/src/app/Tabs.test.ts
+++ b/packages/jmix-react-core/src/app/Tabs.test.ts
@@ -68,14 +68,14 @@ describe('Tabs core API', () => {
     tabs.push(tab1);
     expect(tabs.tabs[0]).toEqual(tab1);
     expect(tabs.currentTab).toEqual(tab1);
-    expect(tabs.currentTab.key).toEqual('tab1__0');
+    expect(tabs.currentTab?.key).toEqual('tab1__0');
     expect(scrollSpy).toHaveBeenCalledWith(0, 0);
 
     tabs.push(tab2);
     expect(tabs.tabs[0]).toEqual(tab1);
     expect(tabs.tabs[1]).toEqual(tab2);
     expect(tabs.currentTab).toEqual(tab2);
-    expect(tabs.currentTab.key).toEqual('tab2__1');
+    expect(tabs.currentTab?.key).toEqual('tab2__1');
     expect(scrollSpy).toHaveBeenCalledWith(0, 0);
   });
 

--- a/packages/jmix-react-core/src/app/Tabs.ts
+++ b/packages/jmix-react-core/src/app/Tabs.ts
@@ -16,7 +16,7 @@ export interface IMultiTabItem {
  */
 export class Tabs {
   @observable.ref tabs: IMultiTabItem[] = [];
-  @observable.ref currentTab: IMultiTabItem = null!;
+  @observable.ref currentTab: IMultiTabItem | undefined = undefined;
   tabsIndex = 0;
 
   constructor() {
@@ -25,7 +25,7 @@ export class Tabs {
     reaction(
       () => [this.currentTab],
       () => {
-        const {screensInTab} = this.currentTab;
+        const screensInTab = this.currentTab?.screensInTab;
         const url = screensInTab?.getUrl();
         if (url != null) {
           redirect(url);

--- a/packages/jmix-react-ui/src/crud/list/ui-callbacks/usePaginationChangeCallback.ts
+++ b/packages/jmix-react-ui/src/crud/list/ui-callbacks/usePaginationChangeCallback.ts
@@ -7,7 +7,7 @@ import {IMultiScreenItem} from "@haulmont/jmix-react-core";
 export function usePaginationChangeCallback<TEntity>(
   entityListState: EntityListState<TEntity>,
   routingPath: string,
-  currentScreen: IMultiScreenItem | null
+  currentScreen?: IMultiScreenItem
 ) {
   return useCallback(
     action((current?: number, pageSize?: number) => {
@@ -18,11 +18,10 @@ export function usePaginationChangeCallback<TEntity>(
       saveHistory(routingPath, entityListState.pagination);
 
       if(currentScreen != null) {
-
         if (currentScreen.params === undefined) {
           currentScreen.params = {}
         }
-  
+
         if (current && pageSize) {
           currentScreen.params.pagination = {
             pageSize,
@@ -32,7 +31,6 @@ export function usePaginationChangeCallback<TEntity>(
           currentScreen.params = undefined;
         }
       }
-
     }),
     [entityListState.pagination, routingPath, currentScreen]
   );

--- a/packages/jmix-react-ui/src/screen-registration/screen-registration.test.tsx
+++ b/packages/jmix-react-ui/src/screen-registration/screen-registration.test.tsx
@@ -46,15 +46,15 @@ describe('Screen registration', () => {
         () => openScreen('screenId', 'menuLink' )
       ).not.toThrow();
 
-      expect(tabs.currentTab.title).toEqual('screenCaption');
-      expect(tabs.currentTab.key).toEqual('menuLink__0');
+      expect(tabs.currentTab?.title).toEqual('screenCaption');
+      expect(tabs.currentTab?.key).toEqual('menuLink__0');
 
       expect(
         () => openScreen('screenId', 'menuLink' )
       ).not.toThrow();
 
-      expect(tabs.currentTab.title).toEqual('screenCaption');
-      expect(tabs.currentTab.key).toEqual('menuLink__0');
+      expect(tabs.currentTab?.title).toEqual('screenCaption');
+      expect(tabs.currentTab?.key).toEqual('menuLink__0');
       expect(tabs.tabs.length).toEqual(1);
       expect(tabs.tabs[0].title).toEqual('screenCaption');
 
@@ -77,15 +77,15 @@ describe('Screen registration', () => {
         () => openScreen('screenId', 'menuLink' )
       ).not.toThrow();
 
-      expect(tabs.currentTab.title).toEqual('screenCaption');
-      expect(tabs.currentTab.key).toEqual('menuLink__0');
+      expect(tabs.currentTab?.title).toEqual('screenCaption');
+      expect(tabs.currentTab?.key).toEqual('menuLink__0');
 
       expect(
         () => openScreen('screenId', 'menuLink' )
       ).not.toThrow();
 
-      expect(tabs.currentTab.title).toEqual('screenCaption');
-      expect(tabs.currentTab.key).toEqual('menuLink__1');
+      expect(tabs.currentTab?.title).toEqual('screenCaption');
+      expect(tabs.currentTab?.key).toEqual('menuLink__1');
       expect(tabs.tabs.length).toEqual(2);
       expect(tabs.tabs[0].title).toEqual('screenCaption');
       expect(tabs.tabs[0].key).toEqual('menuLink__0');

--- a/packages/jmix-react-ui/src/ui/Tabs/index.tsx
+++ b/packages/jmix-react-ui/src/ui/Tabs/index.tsx
@@ -30,7 +30,7 @@ export const MultiTabs = observer(() => {
   }
 
   return (
-    <Tabs activeKey={tabs.currentTab.key} onChange={onTabChange}>
+    <Tabs activeKey={tabs.currentTab?.key} onChange={onTabChange}>
       {tabs.tabs.map((item) => (
         <TabPane
           tab={


### PR DESCRIPTION
affects: @haulmont/jmix-react-core, @haulmont/jmix-react-ui