### PR TITLE
fix: lock typescript on version 4.4.x #774

### DIFF
--- a/example-react-app/package.json
+++ b/example-react-app/package.json
@@ -4,9 +4,9 @@
   "dependencies": {
     "@ant-design/icons": "^4.6.2",
     "@apollo/client": "^3.4.0",
-    "@haulmont/jmix-react-antd": "file:../packages/jmix-react-antd/haulmont-jmix-react-antd-2.0.0-next.4.tgz",
-    "@haulmont/jmix-react-core": "file:../packages/jmix-react-core/haulmont-jmix-react-core-2.0.0-next.3.tgz",
-    "@haulmont/jmix-react-web": "file:../packages/jmix-react-web/haulmont-jmix-react-web-2.0.0-next.3.tgz",
+    "@haulmont/jmix-react-antd": "file:../packages/jmix-react-antd/haulmont-jmix-react-antd-2.0.0-next.5.tgz",
+    "@haulmont/jmix-react-core": "file:../packages/jmix-react-core/haulmont-jmix-react-core-2.0.0-next.4.tgz",
+    "@haulmont/jmix-react-web": "file:../packages/jmix-react-web/haulmont-jmix-react-web-2.0.0-next.4.tgz",
     "@haulmont/jmix-rest": "file:../packages/jmix-rest/haulmont-jmix-rest-2.0.0-next.2.tgz",
     "@haulmont/react-ide-toolbox": "^1.0.0",
     "@haulmont/react-scripts": "^1.0.0",
@@ -28,14 +28,14 @@
     "update-model": "gen-jmix-front sdk:all --dest src/jmix"
   },
   "devDependencies": {
-    "@haulmont/jmix-front-generator": "file:../packages/jmix-front-generator/haulmont-jmix-front-generator-2.0.0-next.5.tgz",
+    "@haulmont/jmix-front-generator": "file:../packages/jmix-front-generator/haulmont-jmix-front-generator-2.0.0-next.6.tgz",
     "@types/jest": "^27.0.0",
     "@types/node": "^10.12.18",
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.1",
     "@types/react-input-mask": "^2.0.5",
     "@types/react-router-dom": "^5.1.5",
-    "typescript": "^4.4.3"
+    "typescript": "~4.4.3"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/jmix-front-generator/package-lock.json
+++ b/packages/jmix-front-generator/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@haulmont/jmix-front-generator",
-			"version": "2.0.0-next.1",
+			"version": "2.0.0-next.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/inquirer-autocomplete-prompt": "^1.3.3",
@@ -21,7 +21,7 @@
 				"node-fetch": "^2.6.2",
 				"prettier": "~1.19.1",
 				"through2": "^2.0.5",
-				"typescript": "^4.4.3",
+				"typescript": "~4.4.3",
 				"uuid": "^3.4.0",
 				"yeoman-environment": "^3.6.0",
 				"yeoman-generator": "^5.4.2"

--- a/packages/jmix-front-generator/package.json
+++ b/packages/jmix-front-generator/package.json
@@ -41,7 +41,7 @@
     "node-fetch": "^2.6.2",
     "prettier": "~1.19.1",
     "through2": "^2.0.5",
-    "typescript": "^4.4.3",
+    "typescript": "~4.4.3",
     "uuid": "^3.4.0",
     "yeoman-environment": "^3.6.0",
     "yeoman-generator": "^5.4.2"

--- a/packages/jmix-front-generator/src/generators/react-typescript/app/template/package.json
+++ b/packages/jmix-front-generator/src/generators/react-typescript/app/template/package.json
@@ -35,7 +35,7 @@
     "@types/react-dom": "^17.0.1",
     "@types/react-input-mask": "^2.0.5",
     "@types/react-router-dom": "^5.1.5",
-    "typescript": "^4.4.3"
+    "typescript": "~4.4.3"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/jmix-react-antd/package-lock.json
+++ b/packages/jmix-react-antd/package-lock.json
@@ -47,7 +47,7 @@
         "rollup-plugin-typescript2": "^0.30.0",
         "ts-jest": "^26.0.0",
         "typedoc": "^0.22.5",
-        "typescript": "^4.4.3"
+        "typescript": "~4.4.3"
       },
       "peerDependencies": {
         "@ant-design/icons": "^4.6.2",

--- a/packages/jmix-react-antd/package.json
+++ b/packages/jmix-react-antd/package.json
@@ -60,7 +60,7 @@
     "rollup-plugin-typescript2": "^0.30.0",
     "ts-jest": "^26.0.0",
     "typedoc": "^0.22.5",
-    "typescript": "^4.4.3"
+    "typescript": "~4.4.3"
   },
   "scripts": {
     "compile": "npm run clean && rollup -c",

--- a/packages/jmix-react-core/package-lock.json
+++ b/packages/jmix-react-core/package-lock.json
@@ -50,7 +50,7 @@
 				"rollup-plugin-node-resolve": "^5.2.0",
 				"ts-jest": "^26.0.0",
 				"typedoc": "^0.22.5",
-				"typescript": "^4.4.3"
+				"typescript": "~4.4.3"
 			},
 			"peerDependencies": {
 				"@apollo/client": "^3.4.0",
@@ -76,7 +76,7 @@
 				"source-map-support": "^0.5.16",
 				"ts-node": "^8.6.2",
 				"typedoc": "^0.22.5",
-				"typescript": "^4.4.3"
+				"typescript": "~4.4.3"
 			},
 			"engines": {
 				"node": ">=12"
@@ -104,7 +104,7 @@
 				"eslint": "^7.32.0",
 				"nodemon": "^2.0.7",
 				"rimraf": "^3.0.2",
-				"typescript": "^4.4.3"
+				"typescript": "~4.4.3"
 			},
 			"engines": {
 				"node": ">=14"

--- a/packages/jmix-react-core/package.json
+++ b/packages/jmix-react-core/package.json
@@ -58,7 +58,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "ts-jest": "^26.0.0",
     "typedoc": "^0.22.5",
-    "typescript": "^4.4.3"
+    "typescript": "~4.4.3"
   },
   "scripts": {
     "compile": "npm run clean && tsc && rollup -c",

--- a/packages/jmix-react-web/package-lock.json
+++ b/packages/jmix-react-web/package-lock.json
@@ -44,7 +44,7 @@
 				"rollup-plugin-typescript2": "^0.30.0",
 				"ts-jest": "^26.0.0",
 				"typedoc": "^0.22.5",
-				"typescript": "^4.4.3"
+				"typescript": "~4.4.3"
 			},
 			"peerDependencies": {
 				"@apollo/client": "^3.4.0",

--- a/packages/jmix-react-web/package.json
+++ b/packages/jmix-react-web/package.json
@@ -55,7 +55,7 @@
     "rollup-plugin-typescript2": "^0.30.0",
     "ts-jest": "^26.0.0",
     "typedoc": "^0.22.5",
-    "typescript": "^4.4.3"
+    "typescript": "~4.4.3"
   },
   "scripts": {
     "compile": "npm run clean && rollup -c",

--- a/packages/jmix-rest/package-lock.json
+++ b/packages/jmix-rest/package-lock.json
@@ -19,7 +19,7 @@
 				"source-map-support": "^0.5.16",
 				"ts-node": "^8.6.2",
 				"typedoc": "^0.22.5",
-				"typescript": "^4.4.3"
+				"typescript": "~4.4.3"
 			},
 			"engines": {
 				"node": ">=12"

--- a/packages/jmix-rest/package.json
+++ b/packages/jmix-rest/package.json
@@ -36,7 +36,7 @@
     "source-map-support": "^0.5.16",
     "ts-node": "^8.6.2",
     "typedoc": "^0.22.5",
-    "typescript": "^4.4.3"
+    "typescript": "~4.4.3"
   },
   "engines": {
     "node": ">=12"

--- a/packages/jmix-server-mock/package-lock.json
+++ b/packages/jmix-server-mock/package-lock.json
@@ -25,7 +25,7 @@
 				"eslint": "^7.32.0",
 				"nodemon": "^2.0.7",
 				"rimraf": "^3.0.2",
-				"typescript": "^4.4.3"
+				"typescript": "~4.4.3"
 			},
 			"engines": {
 				"node": ">=14"

--- a/packages/jmix-server-mock/package.json
+++ b/packages/jmix-server-mock/package.json
@@ -35,7 +35,7 @@
     "eslint": "^7.32.0",
     "nodemon": "^2.0.7",
     "rimraf": "^3.0.2",
-    "typescript": "^4.4.3"
+    "typescript": "~4.4.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
affects: @haulmont/jmix-front-generator, @haulmont/jmix-react-antd, @haulmont/jmix-react-core,
@haulmont/jmix-react-web, @haulmont/jmix-rest, @haulmont/jmix-server-mock