### PR TITLE
fix: collect generator clients only from dirs with info.json file

### DIFF
--- a/packages/jmix-front-generator/src/init.ts
+++ b/packages/jmix-front-generator/src/init.ts
@@ -107,8 +107,12 @@ function collectGeneratorsFromCustomPaths(
 }
 
 function readClientDir(clientsDirPath: string, generatorFileName?: string): GeneratedClientInfo[] {
-  return readdirSync(clientsDirPath).map((clientDirName): GeneratedClientInfo => {
-    return readClient(clientsDirPath, clientDirName, generatorFileName);
+  return readdirSync(clientsDirPath, {withFileTypes: true})
+    .filter(entry => entry.isDirectory())
+    // collect clients only from dirs that contains 'info.json' file
+    .filter(entry => fs.existsSync(path.join(clientsDirPath, entry.name, INFO_FILE_NAME)))
+    .map((dir): GeneratedClientInfo => {
+    return readClient(clientsDirPath, dir.name, generatorFileName);
   });
 }
 


### PR DESCRIPTION
affects: @haulmont/jmix-front-generator

ignore client directories which doesn't contain info.json file while collecting generator clients #833