### PR TITLE
chore: upgrade to TypeScript 4.5 #815

### DIFF
--- a/example-react-app/package.json
+++ b/example-react-app/package.json
@@ -4,10 +4,10 @@
   "dependencies": {
     "@ant-design/icons": "^4.6.2",
     "@apollo/client": "^3.4.0",
-    "@haulmont/jmix-react-antd": "file:../packages/jmix-react-antd/haulmont-jmix-react-antd-2.0.0-next.14.tgz",
-    "@haulmont/jmix-react-core": "file:../packages/jmix-react-core/haulmont-jmix-react-core-2.0.0-next.9.tgz",
-    "@haulmont/jmix-react-web": "file:../packages/jmix-react-web/haulmont-jmix-react-web-2.0.0-next.11.tgz",
-    "@haulmont/jmix-rest": "file:../packages/jmix-rest/haulmont-jmix-rest-2.0.0-next.5.tgz",
+    "@haulmont/jmix-react-antd": "file:../packages/jmix-react-antd/haulmont-jmix-react-antd-2.0.0-next.15.tgz",
+    "@haulmont/jmix-react-core": "file:../packages/jmix-react-core/haulmont-jmix-react-core-2.0.0-next.10.tgz",
+    "@haulmont/jmix-react-web": "file:../packages/jmix-react-web/haulmont-jmix-react-web-2.0.0-next.12.tgz",
+    "@haulmont/jmix-rest": "file:../packages/jmix-rest/haulmont-jmix-rest-2.0.0-next.6.tgz",
     "@haulmont/react-ide-toolbox": "^1.0.0",
     "@haulmont/react-scripts": "^1.0.0",
     "antd": "^4.13.0",
@@ -28,14 +28,14 @@
     "update-model": "gen-jmix-front sdk:all --dest src/jmix"
   },
   "devDependencies": {
-    "@haulmont/jmix-front-generator": "file:../packages/jmix-front-generator/haulmont-jmix-front-generator-2.0.0-next.14.tgz",
+    "@haulmont/jmix-front-generator": "file:../packages/jmix-front-generator/haulmont-jmix-front-generator-2.0.0-next.15.tgz",
     "@types/jest": "^27.0.0",
     "@types/node": "^10.12.18",
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.1",
     "@types/react-input-mask": "^2.0.5",
     "@types/react-router-dom": "^5.1.5",
-    "typescript": "~4.4.3"
+    "typescript": "~4.5.3"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/jmix-addon-charts/package-lock.json
+++ b/packages/jmix-addon-charts/package-lock.json
@@ -6,13 +6,14 @@
 	"packages": {
 		"": {
 			"name": "@haulmont/jmix-addon-charts",
-			"version": "0.1.0-next.0",
+			"version": "0.1.0-next.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@nivo/bar": "^0.74.0",
 				"@nivo/core": "^0.74.0",
 				"@nivo/line": "^0.74.0",
-				"@nivo/pie": "^0.74.0"
+				"@nivo/pie": "^0.74.0",
+				"react-pivottable": "^0.11.0"
 			},
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "^17.0.0",
@@ -25,7 +26,7 @@
 				"rollup-plugin-postcss": "^4.0.0",
 				"rollup-plugin-typescript2": "^0.30.0",
 				"tslib": "^2.3.0",
-				"typescript": "~4.4.3",
+				"typescript": "~4.5.3",
 				"typescript-plugin-css-modules": "^3.4.0"
 			},
 			"peerDependencies": {
@@ -1049,8 +1050,7 @@
 		"node_modules/classnames": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-			"peer": true
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
@@ -1882,6 +1882,14 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/immutability-helper": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.9.1.tgz",
+			"integrity": "sha512-r/RmRG8xO06s/k+PIaif2r5rGc3j4Yhc01jSBfwPCXDLYZwp/yxralI37Df1mwmuzcCsen/E/ITKcTEvc1PQmQ==",
+			"dependencies": {
+				"invariant": "^2.2.0"
+			}
+		},
 		"node_modules/import-cwd": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
@@ -1942,7 +1950,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.0.0"
 			}
@@ -4102,6 +4109,15 @@
 				"react": "17.0.2"
 			}
 		},
+		"node_modules/react-draggable": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.3.2.tgz",
+			"integrity": "sha512-oaz8a6enjbPtx5qb0oDWxtDNuybOylvto1QLydsXgKmwT7e3GXC2eMVDwEMIUYJIFqVG72XpOv673UuuAq6LhA==",
+			"dependencies": {
+				"classnames": "^2.2.5",
+				"prop-types": "^15.6.0"
+			}
+		},
 		"node_modules/react-input-mask": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
@@ -4164,6 +4180,35 @@
 			},
 			"peerDependencies": {
 				"react": "^0.14.9 || ^15.3.0 || ^16.0.0"
+			}
+		},
+		"node_modules/react-pivottable": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/react-pivottable/-/react-pivottable-0.11.0.tgz",
+			"integrity": "sha512-hFU10XYL28NWVRnm+RRyHrzsAn/xIJzPgwPebUE2Hx5JZQl/Zxty3WUL/5cAcdK4AmTb9FQBRopLKLwuiI6VlA==",
+			"dependencies": {
+				"immutability-helper": "^2.3.1",
+				"prop-types": "^15.5.10",
+				"react-draggable": "^3.0.3",
+				"react-sortablejs": "^1.3.4",
+				"sortablejs": "^1.6.1"
+			},
+			"peerDependencies": {
+				"react": ">=15.0.0",
+				"react-dom": ">=15.0.0"
+			}
+		},
+		"node_modules/react-sortablejs": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/react-sortablejs/-/react-sortablejs-1.5.1.tgz",
+			"integrity": "sha512-bKIc1UVhjZt55Nb6WZFxZ8Jwyngg8CTt+w+iG1pA5k9LQsg1J0X6nLppHatSSDZDECtRZKp2z47tmmhPRJNj4g==",
+			"dependencies": {
+				"prop-types": ">=15.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=15.0.0",
+				"react-dom": ">=15.0.0",
+				"sortablejs": "^1.6.1"
 			}
 		},
 		"node_modules/readdirp": {
@@ -4421,6 +4466,11 @@
 			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
 			"peer": true
 		},
+		"node_modules/sortablejs": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+			"integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w=="
+		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4664,9 +4714,9 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"devOptional": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5541,8 +5591,7 @@
 		"classnames": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-			"peer": true
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
 		},
 		"color-convert": {
 			"version": "2.0.1",
@@ -6200,6 +6249,14 @@
 			"dev": true,
 			"optional": true
 		},
+		"immutability-helper": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.9.1.tgz",
+			"integrity": "sha512-r/RmRG8xO06s/k+PIaif2r5rGc3j4Yhc01jSBfwPCXDLYZwp/yxralI37Df1mwmuzcCsen/E/ITKcTEvc1PQmQ==",
+			"requires": {
+				"invariant": "^2.2.0"
+			}
+		},
 		"import-cwd": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
@@ -6254,7 +6311,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"peer": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -7813,6 +7869,15 @@
 				"scheduler": "^0.20.2"
 			}
 		},
+		"react-draggable": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.3.2.tgz",
+			"integrity": "sha512-oaz8a6enjbPtx5qb0oDWxtDNuybOylvto1QLydsXgKmwT7e3GXC2eMVDwEMIUYJIFqVG72XpOv673UuuAq6LhA==",
+			"requires": {
+				"classnames": "^2.2.5",
+				"prop-types": "^15.6.0"
+			}
+		},
 		"react-input-mask": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
@@ -7859,6 +7924,26 @@
 				"performance-now": "^0.2.0",
 				"prop-types": "^15.5.8",
 				"raf": "^3.1.0"
+			}
+		},
+		"react-pivottable": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/react-pivottable/-/react-pivottable-0.11.0.tgz",
+			"integrity": "sha512-hFU10XYL28NWVRnm+RRyHrzsAn/xIJzPgwPebUE2Hx5JZQl/Zxty3WUL/5cAcdK4AmTb9FQBRopLKLwuiI6VlA==",
+			"requires": {
+				"immutability-helper": "^2.3.1",
+				"prop-types": "^15.5.10",
+				"react-draggable": "^3.0.3",
+				"react-sortablejs": "^1.3.4",
+				"sortablejs": "^1.6.1"
+			}
+		},
+		"react-sortablejs": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/react-sortablejs/-/react-sortablejs-1.5.1.tgz",
+			"integrity": "sha512-bKIc1UVhjZt55Nb6WZFxZ8Jwyngg8CTt+w+iG1pA5k9LQsg1J0X6nLppHatSSDZDECtRZKp2z47tmmhPRJNj4g==",
+			"requires": {
+				"prop-types": ">=15.0.0"
 			}
 		},
 		"readdirp": {
@@ -8070,6 +8155,11 @@
 			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
 			"peer": true
 		},
+		"sortablejs": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+			"integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w=="
+		},
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8270,9 +8360,9 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"devOptional": true
 		},
 		"typescript-plugin-css-modules": {

--- a/packages/jmix-addon-charts/package.json
+++ b/packages/jmix-addon-charts/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-postcss": "^4.0.0",
     "rollup-plugin-typescript2": "^0.30.0",
     "tslib": "^2.3.0",
-    "typescript": "~4.4.3",
+    "typescript": "~4.5.3",
     "typescript-plugin-css-modules": "^3.4.0"
   },
   "scripts": {

--- a/packages/jmix-front-generator/package-lock.json
+++ b/packages/jmix-front-generator/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@haulmont/jmix-front-generator",
-			"version": "2.0.0-next.14",
+			"version": "2.0.0-next.16",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/inquirer-autocomplete-prompt": "^1.3.3",
@@ -21,7 +21,7 @@
 				"node-fetch": "^2.6.2",
 				"prettier": "~1.19.1",
 				"through2": "^2.0.5",
-				"typescript": "~4.4.3",
+				"typescript": "~4.5.3",
 				"uuid": "^3.4.0",
 				"yeoman-environment": "^3.6.0",
 				"yeoman-generator": "^5.4.2"
@@ -10721,9 +10721,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -20232,9 +20232,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA=="
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ=="
 		},
 		"unc-path-regex": {
 			"version": "0.1.2",

--- a/packages/jmix-front-generator/package.json
+++ b/packages/jmix-front-generator/package.json
@@ -41,7 +41,7 @@
     "node-fetch": "^2.6.2",
     "prettier": "~1.19.1",
     "through2": "^2.0.5",
-    "typescript": "~4.4.3",
+    "typescript": "~4.5.3",
     "uuid": "^3.4.0",
     "yeoman-environment": "^3.6.0",
     "yeoman-generator": "^5.4.2"

--- a/packages/jmix-front-generator/src/building-blocks/stages/writing/pieces/sdk/import-utils.ts
+++ b/packages/jmix-front-generator/src/building-blocks/stages/writing/pieces/sdk/import-utils.ts
@@ -37,16 +37,17 @@ export function createIncludes(importInfos: ImportInfo[], current?: ImportInfo):
 
 export function importDeclaration(identifiers: string[], moduleSpec: string): ImportDeclaration {
   const elements = identifiers.map(idn =>
-    ts.createImportSpecifier(undefined, ts.createIdentifier(idn)));
+    ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier(idn)));
 
-  return ts.createImportDeclaration(
-    undefined,
-    undefined,
-    ts.createImportClause(
+    return ts.factory.createImportDeclaration(
       undefined,
-      ts.createNamedImports(elements)
-    ),
-    ts.createLiteral(moduleSpec),
+      undefined,
+      ts.factory.createImportClause(
+        false,
+        undefined,
+        ts.factory.createNamedImports(elements)
+      ),
+      ts.factory.createStringLiteral(moduleSpec)
   );
 }
 

--- a/packages/jmix-front-generator/src/generators/react-typescript/app/template/package.json
+++ b/packages/jmix-front-generator/src/generators/react-typescript/app/template/package.json
@@ -35,7 +35,7 @@
     "@types/react-dom": "^17.0.1",
     "@types/react-input-mask": "^2.0.5",
     "@types/react-router-dom": "^5.1.5",
-    "typescript": "~4.4.3"
+    "typescript": "~4.5.3"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/jmix-react-antd/package-lock.json
+++ b/packages/jmix-react-antd/package-lock.json
@@ -6,10 +6,14 @@
 	"packages": {
 		"": {
 			"name": "@haulmont/jmix-react-antd",
-			"version": "2.0.0-next.14",
+			"version": "2.0.0-next.16",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"react-ace": "^9.5.0"
+				"draft-js": "^0.11.7",
+				"draftjs-to-html": "^0.9.1",
+				"html-to-draftjs": "^1.5.0",
+				"react-ace": "^9.5.0",
+				"react-draft-wysiwyg": "^1.14.7"
 			},
 			"devDependencies": {
 				"@babel/preset-env": "^7.8.4",
@@ -47,23 +51,19 @@
 				"rollup-plugin-postcss": "^4.0.0",
 				"rollup-plugin-typescript2": "^0.30.0",
 				"ts-jest": "^26.0.0",
-				"typedoc": "^0.22.5",
-				"typescript": "~4.4.3"
+				"typedoc": "^0.22.10",
+				"typescript": "~4.5.3"
 			},
 			"peerDependencies": {
 				"@ant-design/icons": "^4.6.2",
 				"@apollo/client": "^3.4.0",
 				"antd": "^4.13.0",
 				"dayjs": "^1.10.4",
-				"draft-js": "^0.11.7",
-				"draftjs-to-html": "^0.9.1",
 				"graphql": "^15.4.0",
-				"html-to-draftjs": "^1.5.0",
 				"mobx": "^6.3.3",
 				"mobx-react": "^7.2.0",
 				"react": "^17.0.1",
 				"react-dom": "^17.0.1",
-				"react-draft-wysiwyg": "^1.14.7",
 				"react-input-mask": "^2.0.4",
 				"react-intl": "^5.20.10"
 			}
@@ -3789,8 +3789,7 @@
 		"node_modules/asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"peer": true
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"node_modules/assign-symbols": {
 			"version": "1.0.0",
@@ -4468,8 +4467,7 @@
 		"node_modules/classnames": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-			"peer": true
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
 		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
@@ -4661,7 +4659,6 @@
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.3.tgz",
 			"integrity": "sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g==",
 			"hasInstallScript": true,
-			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
@@ -4711,7 +4708,6 @@
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
 			"integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-			"peer": true,
 			"dependencies": {
 				"node-fetch": "2.6.1"
 			}
@@ -5222,7 +5218,6 @@
 			"version": "0.11.7",
 			"resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.7.tgz",
 			"integrity": "sha512-ne7yFfN4sEL82QPQEn80xnADR8/Q6ALVworbC5UOSzOvjffmYfFsr3xSZtxbIirti14R7Y33EZC5rivpLgIbsg==",
-			"peer": true,
 			"dependencies": {
 				"fbjs": "^2.0.0",
 				"immutable": "~3.7.4",
@@ -5237,7 +5232,6 @@
 			"version": "3.7.6",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
 			"integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks=",
-			"peer": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -5245,14 +5239,12 @@
 		"node_modules/draftjs-to-html": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/draftjs-to-html/-/draftjs-to-html-0.9.1.tgz",
-			"integrity": "sha512-fFstE6+IayaVFBEvaFt/wN8vdj8FsTRzij7dy7LI9QIwf5LgfHFi9zSpvCg+feJ2tbYVqHxUkjcibwpsTpgFVQ==",
-			"peer": true
+			"integrity": "sha512-fFstE6+IayaVFBEvaFt/wN8vdj8FsTRzij7dy7LI9QIwf5LgfHFi9zSpvCg+feJ2tbYVqHxUkjcibwpsTpgFVQ=="
 		},
 		"node_modules/draftjs-utils": {
 			"version": "0.10.2",
 			"resolved": "https://registry.npmjs.org/draftjs-utils/-/draftjs-utils-0.10.2.tgz",
 			"integrity": "sha512-EstHqr3R3JVcilJrBaO/A+01GvwwKmC7e4TCjC7S94ZeMh4IVmf60OuQXtHHpwItK8C2JCi3iljgN5KHkJboUg==",
-			"peer": true,
 			"peerDependencies": {
 				"draft-js": "^0.11.x",
 				"immutable": "3.x.x || 4.x.x"
@@ -6285,7 +6277,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-2.0.0.tgz",
 			"integrity": "sha512-8XA8ny9ifxrAWlyhAbexXcs3rRMtxWcs3M0lctLfB49jRDHiaxj+Mo0XxbwE7nKZYzgCFoq64FS+WFd4IycPPQ==",
-			"peer": true,
 			"dependencies": {
 				"core-js": "^3.6.4",
 				"cross-fetch": "^3.0.4",
@@ -6300,8 +6291,7 @@
 		"node_modules/fbjs-css-vars": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
-			"peer": true
+			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
 		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
@@ -6828,7 +6818,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/html-to-draftjs/-/html-to-draftjs-1.5.0.tgz",
 			"integrity": "sha512-kggLXBNciKDwKf+KYsuE+V5gw4dZ7nHyGMX9m0wy7urzWjKGWyNFetmArRLvRV0VrxKN70WylFsJvMTJx02OBQ==",
-			"peer": true,
 			"peerDependencies": {
 				"draft-js": "^0.10.x || ^0.11.x",
 				"immutable": "3.x.x || 4.x.x"
@@ -9567,7 +9556,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
 			"integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-			"peer": true,
 			"dependencies": {
 				"uc.micro": "^1.0.1"
 			}
@@ -9754,9 +9742,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.7.tgz",
-			"integrity": "sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+			"integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
 			"dev": true,
 			"bin": {
 				"marked": "bin/marked"
@@ -10029,7 +10017,6 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
 			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-			"peer": true,
 			"engines": {
 				"node": "4.x || >=6.0.0"
 			}
@@ -11333,7 +11320,6 @@
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"peer": true,
 			"dependencies": {
 				"asap": "~2.0.3"
 			}
@@ -12071,7 +12057,6 @@
 			"version": "1.14.7",
 			"resolved": "https://registry.npmjs.org/react-draft-wysiwyg/-/react-draft-wysiwyg-1.14.7.tgz",
 			"integrity": "sha512-D4X8F/ourvQZuqHzCQ6Vs6Tnt6TbGH58kvHQxC+aZGq+45ko2EyatL6G5C/paMaNKDZq2JRe7yAzykneMLpNOg==",
-			"peer": true,
 			"dependencies": {
 				"classnames": "^2.2.6",
 				"draftjs-utils": "^0.10.2",
@@ -13139,8 +13124,7 @@
 		"node_modules/setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"peer": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"node_modules/shallowequal": {
 			"version": "1.1.0",
@@ -14333,17 +14317,16 @@
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.22.5",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.5.tgz",
-			"integrity": "sha512-KFrWGU1iKiTGw0RcyjLNYDmhd7uICU14HgBNPmFKY/sT4Pm/fraaLyWyisst9vGTUAKxqibqoDITR7+ZcAkhHg==",
+			"version": "0.22.10",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+			"integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"dependencies": {
 				"glob": "^7.2.0",
 				"lunr": "^2.3.9",
-				"marked": "^3.0.4",
+				"marked": "^3.0.8",
 				"minimatch": "^3.0.4",
-				"shiki": "^0.9.11"
+				"shiki": "^0.9.12"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
@@ -14352,13 +14335,13 @@
 				"node": ">= 12.10.0"
 			},
 			"peerDependencies": {
-				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x"
+				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"devOptional": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -14382,7 +14365,6 @@
 					"url": "https://paypal.me/faisalman"
 				}
 			],
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -14390,8 +14372,7 @@
 		"node_modules/uc.micro": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-			"peer": true
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
 		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.1",
@@ -17752,8 +17733,7 @@
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"peer": true
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
@@ -18279,8 +18259,7 @@
 		"classnames": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-			"peer": true
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
 		},
 		"cliui": {
 			"version": "7.0.4",
@@ -18449,8 +18428,7 @@
 		"core-js": {
 			"version": "3.19.3",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.3.tgz",
-			"integrity": "sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g==",
-			"peer": true
+			"integrity": "sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g=="
 		},
 		"core-js-compat": {
 			"version": "3.16.1",
@@ -18486,7 +18464,6 @@
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
 			"integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-			"peer": true,
 			"requires": {
 				"node-fetch": "2.6.1"
 			}
@@ -18870,7 +18847,6 @@
 			"version": "0.11.7",
 			"resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.7.tgz",
 			"integrity": "sha512-ne7yFfN4sEL82QPQEn80xnADR8/Q6ALVworbC5UOSzOvjffmYfFsr3xSZtxbIirti14R7Y33EZC5rivpLgIbsg==",
-			"peer": true,
 			"requires": {
 				"fbjs": "^2.0.0",
 				"immutable": "~3.7.4",
@@ -18880,22 +18856,19 @@
 				"immutable": {
 					"version": "3.7.6",
 					"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
-					"integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks=",
-					"peer": true
+					"integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
 				}
 			}
 		},
 		"draftjs-to-html": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/draftjs-to-html/-/draftjs-to-html-0.9.1.tgz",
-			"integrity": "sha512-fFstE6+IayaVFBEvaFt/wN8vdj8FsTRzij7dy7LI9QIwf5LgfHFi9zSpvCg+feJ2tbYVqHxUkjcibwpsTpgFVQ==",
-			"peer": true
+			"integrity": "sha512-fFstE6+IayaVFBEvaFt/wN8vdj8FsTRzij7dy7LI9QIwf5LgfHFi9zSpvCg+feJ2tbYVqHxUkjcibwpsTpgFVQ=="
 		},
 		"draftjs-utils": {
 			"version": "0.10.2",
 			"resolved": "https://registry.npmjs.org/draftjs-utils/-/draftjs-utils-0.10.2.tgz",
 			"integrity": "sha512-EstHqr3R3JVcilJrBaO/A+01GvwwKmC7e4TCjC7S94ZeMh4IVmf60OuQXtHHpwItK8C2JCi3iljgN5KHkJboUg==",
-			"peer": true,
 			"requires": {}
 		},
 		"electron-to-chromium": {
@@ -19686,7 +19659,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-2.0.0.tgz",
 			"integrity": "sha512-8XA8ny9ifxrAWlyhAbexXcs3rRMtxWcs3M0lctLfB49jRDHiaxj+Mo0XxbwE7nKZYzgCFoq64FS+WFd4IycPPQ==",
-			"peer": true,
 			"requires": {
 				"core-js": "^3.6.4",
 				"cross-fetch": "^3.0.4",
@@ -19701,8 +19673,7 @@
 		"fbjs-css-vars": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
-			"peer": true
+			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
 		},
 		"file-entry-cache": {
 			"version": "6.0.1",
@@ -20107,7 +20078,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/html-to-draftjs/-/html-to-draftjs-1.5.0.tgz",
 			"integrity": "sha512-kggLXBNciKDwKf+KYsuE+V5gw4dZ7nHyGMX9m0wy7urzWjKGWyNFetmArRLvRV0VrxKN70WylFsJvMTJx02OBQ==",
-			"peer": true,
 			"requires": {}
 		},
 		"http-proxy-agent": {
@@ -22180,7 +22150,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
 			"integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-			"peer": true,
 			"requires": {
 				"uc.micro": "^1.0.1"
 			}
@@ -22345,9 +22314,9 @@
 			}
 		},
 		"marked": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.7.tgz",
-			"integrity": "sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+			"integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
 			"dev": true
 		},
 		"mdn-data": {
@@ -22530,8 +22499,7 @@
 		"node-fetch": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-			"peer": true
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -23445,7 +23413,6 @@
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"peer": true,
 			"requires": {
 				"asap": "~2.0.3"
 			}
@@ -23972,7 +23939,6 @@
 			"version": "1.14.7",
 			"resolved": "https://registry.npmjs.org/react-draft-wysiwyg/-/react-draft-wysiwyg-1.14.7.tgz",
 			"integrity": "sha512-D4X8F/ourvQZuqHzCQ6Vs6Tnt6TbGH58kvHQxC+aZGq+45ko2EyatL6G5C/paMaNKDZq2JRe7yAzykneMLpNOg==",
-			"peer": true,
 			"requires": {
 				"classnames": "^2.2.6",
 				"draftjs-utils": "^0.10.2",
@@ -24812,8 +24778,7 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"peer": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"shallowequal": {
 			"version": "1.1.0",
@@ -25789,35 +25754,33 @@
 			}
 		},
 		"typedoc": {
-			"version": "0.22.5",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.5.tgz",
-			"integrity": "sha512-KFrWGU1iKiTGw0RcyjLNYDmhd7uICU14HgBNPmFKY/sT4Pm/fraaLyWyisst9vGTUAKxqibqoDITR7+ZcAkhHg==",
+			"version": "0.22.10",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+			"integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.2.0",
 				"lunr": "^2.3.9",
-				"marked": "^3.0.4",
+				"marked": "^3.0.8",
 				"minimatch": "^3.0.4",
-				"shiki": "^0.9.11"
+				"shiki": "^0.9.12"
 			}
 		},
 		"typescript": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"devOptional": true
 		},
 		"ua-parser-js": {
 			"version": "0.7.31",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-			"integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
-			"peer": true
+			"integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
 		},
 		"uc.micro": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-			"peer": true
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
 		},
 		"unbox-primitive": {
 			"version": "1.0.1",

--- a/packages/jmix-react-antd/package.json
+++ b/packages/jmix-react-antd/package.json
@@ -67,8 +67,8 @@
     "rollup-plugin-postcss": "^4.0.0",
     "rollup-plugin-typescript2": "^0.30.0",
     "ts-jest": "^26.0.0",
-    "typedoc": "^0.22.5",
-    "typescript": "~4.4.3"
+    "typedoc": "^0.22.10",
+    "typescript": "~4.5.3"
   },
   "scripts": {
     "compile": "npm run clean && rollup -c",

--- a/packages/jmix-react-core/package-lock.json
+++ b/packages/jmix-react-core/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@haulmont/jmix-react-core",
-			"version": "2.0.0-next.9",
+			"version": "2.0.0-next.11",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"apollo-upload-client": "^16.0.0",
@@ -49,8 +49,8 @@
 				"rollup-plugin-json": "^4.0.0",
 				"rollup-plugin-node-resolve": "^5.2.0",
 				"ts-jest": "^26.0.0",
-				"typedoc": "^0.22.5",
-				"typescript": "~4.4.3"
+				"typedoc": "^0.22.10",
+				"typescript": "~4.5.3"
 			},
 			"peerDependencies": {
 				"@apollo/client": "^3.4.0",
@@ -9613,9 +9613,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.7.tgz",
-			"integrity": "sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+			"integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
 			"dev": true,
 			"bin": {
 				"marked": "bin/marked"
@@ -12212,16 +12212,16 @@
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.22.6",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.6.tgz",
-			"integrity": "sha512-ePbJqOaz0GNkU2ehRwFwBpLD4Gp6m7jbJfHysXmDdjVKc1g8DFJ83r/LOZ9TZrkC661vgpoIY3FjSPEtUilHNA==",
+			"version": "0.22.10",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+			"integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
 			"dev": true,
 			"dependencies": {
 				"glob": "^7.2.0",
 				"lunr": "^2.3.9",
-				"marked": "^3.0.4",
+				"marked": "^3.0.8",
 				"minimatch": "^3.0.4",
-				"shiki": "^0.9.11"
+				"shiki": "^0.9.12"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
@@ -12230,13 +12230,13 @@
 				"node": ">= 12.10.0"
 			},
 			"peerDependencies": {
-				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x"
+				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -18884,9 +18884,9 @@
 			}
 		},
 		"marked": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.7.tgz",
-			"integrity": "sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+			"integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
 			"dev": true
 		},
 		"merge-stream": {
@@ -20592,22 +20592,22 @@
 			}
 		},
 		"typedoc": {
-			"version": "0.22.6",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.6.tgz",
-			"integrity": "sha512-ePbJqOaz0GNkU2ehRwFwBpLD4Gp6m7jbJfHysXmDdjVKc1g8DFJ83r/LOZ9TZrkC661vgpoIY3FjSPEtUilHNA==",
+			"version": "0.22.10",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+			"integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.2.0",
 				"lunr": "^2.3.9",
-				"marked": "^3.0.4",
+				"marked": "^3.0.8",
 				"minimatch": "^3.0.4",
-				"shiki": "^0.9.11"
+				"shiki": "^0.9.12"
 			}
 		},
 		"typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"dev": true
 		},
 		"unbox-primitive": {

--- a/packages/jmix-react-core/package.json
+++ b/packages/jmix-react-core/package.json
@@ -57,8 +57,8 @@
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "ts-jest": "^26.0.0",
-    "typedoc": "^0.22.5",
-    "typescript": "~4.4.3"
+    "typedoc": "^0.22.10",
+    "typescript": "~4.5.3"
   },
   "scripts": {
     "compile": "npm run clean && tsc && rollup -c",

--- a/packages/jmix-react-web/package-lock.json
+++ b/packages/jmix-react-web/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@haulmont/jmix-react-web",
-			"version": "2.0.0-next.11",
+			"version": "2.0.0-next.13",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"hotkeys-js": "^3.8.7"
@@ -43,8 +43,8 @@
 				"rollup-plugin-postcss": "^4.0.0",
 				"rollup-plugin-typescript2": "^0.30.0",
 				"ts-jest": "^26.0.0",
-				"typedoc": "^0.22.5",
-				"typescript": "~4.4.3"
+				"typedoc": "^0.22.10",
+				"typescript": "~4.5.3"
 			},
 			"peerDependencies": {
 				"@apollo/client": "^3.4.0",
@@ -11430,9 +11430,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.7.tgz",
-			"integrity": "sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+			"integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
 			"dev": true,
 			"bin": {
 				"marked": "bin/marked"
@@ -15352,17 +15352,16 @@
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.22.5",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.5.tgz",
-			"integrity": "sha512-KFrWGU1iKiTGw0RcyjLNYDmhd7uICU14HgBNPmFKY/sT4Pm/fraaLyWyisst9vGTUAKxqibqoDITR7+ZcAkhHg==",
+			"version": "0.22.10",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+			"integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"dependencies": {
 				"glob": "^7.2.0",
 				"lunr": "^2.3.9",
-				"marked": "^3.0.4",
+				"marked": "^3.0.8",
 				"minimatch": "^3.0.4",
-				"shiki": "^0.9.11"
+				"shiki": "^0.9.12"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
@@ -15371,13 +15370,13 @@
 				"node": ">= 12.10.0"
 			},
 			"peerDependencies": {
-				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x"
+				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"devOptional": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -24657,9 +24656,9 @@
 			}
 		},
 		"marked": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.7.tgz",
-			"integrity": "sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+			"integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
 			"dev": true
 		},
 		"mdn-data": {
@@ -27620,22 +27619,22 @@
 			}
 		},
 		"typedoc": {
-			"version": "0.22.5",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.5.tgz",
-			"integrity": "sha512-KFrWGU1iKiTGw0RcyjLNYDmhd7uICU14HgBNPmFKY/sT4Pm/fraaLyWyisst9vGTUAKxqibqoDITR7+ZcAkhHg==",
+			"version": "0.22.10",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+			"integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.2.0",
 				"lunr": "^2.3.9",
-				"marked": "^3.0.4",
+				"marked": "^3.0.8",
 				"minimatch": "^3.0.4",
-				"shiki": "^0.9.11"
+				"shiki": "^0.9.12"
 			}
 		},
 		"typescript": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"devOptional": true
 		},
 		"unbox-primitive": {

--- a/packages/jmix-react-web/package.json
+++ b/packages/jmix-react-web/package.json
@@ -54,8 +54,8 @@
     "rollup-plugin-postcss": "^4.0.0",
     "rollup-plugin-typescript2": "^0.30.0",
     "ts-jest": "^26.0.0",
-    "typedoc": "^0.22.5",
-    "typescript": "~4.4.3"
+    "typedoc": "^0.22.10",
+    "typescript": "~4.5.3"
   },
   "scripts": {
     "compile": "npm run clean && rollup -c",

--- a/packages/jmix-rest/package-lock.json
+++ b/packages/jmix-rest/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@haulmont/jmix-rest",
-			"version": "2.0.0-next.5",
+			"version": "2.0.0-next.6",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@typescript-eslint/eslint-plugin": "^4.30.0",
@@ -18,8 +18,8 @@
 				"node-fetch": "^2.6.2",
 				"source-map-support": "^0.5.16",
 				"ts-node": "^8.6.2",
-				"typedoc": "^0.22.5",
-				"typescript": "~4.4.3"
+				"typedoc": "^0.22.10",
+				"typescript": "~4.5.3"
 			},
 			"engines": {
 				"node": ">=12"
@@ -5799,9 +5799,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.7.tgz",
-			"integrity": "sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+			"integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
 			"dev": true,
 			"bin": {
 				"marked": "bin/marked"
@@ -8504,17 +8504,16 @@
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.22.5",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.5.tgz",
-			"integrity": "sha512-KFrWGU1iKiTGw0RcyjLNYDmhd7uICU14HgBNPmFKY/sT4Pm/fraaLyWyisst9vGTUAKxqibqoDITR7+ZcAkhHg==",
+			"version": "0.22.10",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+			"integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"dependencies": {
 				"glob": "^7.2.0",
 				"lunr": "^2.3.9",
-				"marked": "^3.0.4",
+				"marked": "^3.0.8",
 				"minimatch": "^3.0.4",
-				"shiki": "^0.9.11"
+				"shiki": "^0.9.12"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
@@ -8523,13 +8522,13 @@
 				"node": ">= 12.10.0"
 			},
 			"peerDependencies": {
-				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x"
+				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -13606,9 +13605,9 @@
 			}
 		},
 		"marked": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.7.tgz",
-			"integrity": "sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+			"integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
 			"dev": true
 		},
 		"md5.js": {
@@ -15801,22 +15800,22 @@
 			}
 		},
 		"typedoc": {
-			"version": "0.22.5",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.5.tgz",
-			"integrity": "sha512-KFrWGU1iKiTGw0RcyjLNYDmhd7uICU14HgBNPmFKY/sT4Pm/fraaLyWyisst9vGTUAKxqibqoDITR7+ZcAkhHg==",
+			"version": "0.22.10",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+			"integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.2.0",
 				"lunr": "^2.3.9",
-				"marked": "^3.0.4",
+				"marked": "^3.0.8",
 				"minimatch": "^3.0.4",
-				"shiki": "^0.9.11"
+				"shiki": "^0.9.12"
 			}
 		},
 		"typescript": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"dev": true
 		},
 		"umd": {

--- a/packages/jmix-rest/package.json
+++ b/packages/jmix-rest/package.json
@@ -35,8 +35,8 @@
     "node-fetch": "^2.6.2",
     "source-map-support": "^0.5.16",
     "ts-node": "^8.6.2",
-    "typedoc": "^0.22.5",
-    "typescript": "~4.4.3"
+    "typedoc": "^0.22.10",
+    "typescript": "~4.5.3"
   },
   "engines": {
     "node": ">=12"

--- a/packages/jmix-server-mock/package-lock.json
+++ b/packages/jmix-server-mock/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@haulmont/jmix-server-mock",
-			"version": "2.0.0-next.4",
+			"version": "2.0.0-next.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"apollo-server-express": "^2.24.0",
@@ -25,7 +25,7 @@
 				"eslint": "^7.32.0",
 				"nodemon": "^2.0.7",
 				"rimraf": "^3.0.2",
-				"typescript": "~4.4.3"
+				"typescript": "~4.5.3"
 			},
 			"engines": {
 				"node": ">=14"
@@ -4493,9 +4493,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -8199,9 +8199,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+			"integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
 			"dev": true
 		},
 		"unbox-primitive": {

--- a/packages/jmix-server-mock/package.json
+++ b/packages/jmix-server-mock/package.json
@@ -35,7 +35,7 @@
     "eslint": "^7.32.0",
     "nodemon": "^2.0.7",
     "rimraf": "^3.0.2",
-    "typescript": "~4.4.3"
+    "typescript": "~4.5.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
affects: eslint-config-jmix-react, @haulmont/jmix-addon-charts, @haulmont/jmix-addon-data-tools,
@haulmont/jmix-front-generator, @haulmont/jmix-react-antd, @haulmont/jmix-react-core,
@haulmont/jmix-react-web, @haulmont/jmix-rest, @haulmont/jmix-server-mock