### PR TITLE
fix: move modules to dependencies #846

### DIFF
--- a/packages/jmix-react-antd/package.json
+++ b/packages/jmix-react-antd/package.json
@@ -12,22 +12,22 @@
     "@haulmont/jmix-react-core": "^2.0.0-next.9",
     "@haulmont/jmix-react-web": "^2.0.0-next.11",
     "@haulmont/jmix-rest": "^2.0.0-next.5",
-    "react-ace": "^9.5.0"
+    "react-ace": "^9.5.0",
+    "html-to-draftjs": "^1.5.0",
+    "draftjs-to-html": "^0.9.1",
+    "draft-js": "^0.11.7",
+    "react-draft-wysiwyg": "^1.14.7"
   },
   "peerDependencies": {
     "@ant-design/icons": "^4.6.2",
     "@apollo/client": "^3.4.0",
     "antd": "^4.13.0",
     "dayjs": "^1.10.4",
-    "draft-js": "^0.11.7",
-    "draftjs-to-html": "^0.9.1",
     "graphql": "^15.4.0",
-    "html-to-draftjs": "^1.5.0",
     "mobx": "^6.3.3",
     "mobx-react": "^7.2.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-draft-wysiwyg": "^1.14.7",
     "react-input-mask": "^2.0.4",
     "react-intl": "^5.20.10"
   },


### PR DESCRIPTION
affects: @haulmont/jmix-react-antd