### PR TITLE
fix: add immutable module to dependencies #857

### DIFF
--- a/packages/jmix-react-antd/package.json
+++ b/packages/jmix-react-antd/package.json
@@ -12,6 +12,7 @@
     "@haulmont/jmix-react-core": "^2.0.0-next.10",
     "@haulmont/jmix-react-web": "^2.0.0-next.12",
     "@haulmont/jmix-rest": "^2.0.0-next.6",
+    "immutable": "^4.0.0",
     "draft-js": "^0.11.7",
     "draftjs-to-html": "^0.9.1",
     "html-to-draftjs": "^1.5.0",


### PR DESCRIPTION
affects: @haulmont/jmix-react-antd