### PR TITLE
fix: filter recurtion relations in generated graphQL list queries

### DIFF
--- a/packages/jmix-front-generator/src/generators/react-typescript/entity-master-detail/template/Table.tsx.ejs
+++ b/packages/jmix-front-generator/src/generators/react-typescript/entity-master-detail/template/Table.tsx.ejs
@@ -23,7 +23,7 @@ const <%= dollarsToUnderscores(entity.name).toUpperCase() %>_LIST = gql`
   query <%= dollarsToUnderscores(entity.name) %>List($limit: Int, $offset: Int, $orderBy: inp_<%= dollarsToUnderscores(entity.name) %>OrderBy, $filter: [inp_<%= dollarsToUnderscores(entity.name) %>FilterCondition]) {
     <%= dollarsToUnderscores(entity.name) %>Count(filter: $filter)
     <%= dollarsToUnderscores(entity.name) %>List(limit: $limit, offset: $offset, orderBy: $orderBy, filter: $filter) <%= query %>
-    <% Object.keys(relations).forEach(attrName => { %>
+    <% Object.keys(relations).filter(attrName => relations[attrName].name !== entity.name).forEach(attrName => { %>
       <%= dollarsToUnderscores(relations[attrName].name) %>List {
       id
       _instanceName

--- a/packages/jmix-front-generator/src/generators/react-typescript/entity-multi-selection-table/template/MultiSelectionTable.tsx.ejs
+++ b/packages/jmix-front-generator/src/generators/react-typescript/entity-multi-selection-table/template/MultiSelectionTable.tsx.ejs
@@ -26,7 +26,7 @@ const <%= dollarsToUnderscores(entity.name).toUpperCase() %>_LIST = gql`
   query <%= dollarsToUnderscores(entity.name) %>List($limit: Int, $offset: Int, $orderBy: inp_<%= dollarsToUnderscores(entity.name) %>OrderBy, $filter: [inp_<%= dollarsToUnderscores(entity.name) %>FilterCondition]) {
     <%= dollarsToUnderscores(entity.name) %>Count(filter: $filter)
     <%= dollarsToUnderscores(entity.name) %>List(limit: $limit, offset: $offset, orderBy: $orderBy, filter: $filter) <%= query %>
-    <% Object.keys(relations).forEach(attrName => { %>
+    <% Object.keys(relations).filter(attrName => relations[attrName].name !== entity.name).forEach(attrName => { %>
       <%= dollarsToUnderscores(relations[attrName].name) %>List {
       id
       _instanceName


### PR DESCRIPTION
affects: @haulmont/jmix-front-generator