### PR TITLE
feat: add ability to use intl API outside of React components #859

### DIFF
--- a/example-react-app/package.json
+++ b/example-react-app/package.json
@@ -4,10 +4,10 @@
   "dependencies": {
     "@ant-design/icons": "^4.6.2",
     "@apollo/client": "^3.4.0",
-    "@haulmont/jmix-react-antd": "file:../packages/jmix-react-antd/haulmont-jmix-react-antd-2.0.0-next.17.tgz",
-    "@haulmont/jmix-react-core": "file:../packages/jmix-react-core/haulmont-jmix-react-core-2.0.0-next.12.tgz",
-    "@haulmont/jmix-react-web": "file:../packages/jmix-react-web/haulmont-jmix-react-web-2.0.0-next.14.tgz",
-    "@haulmont/jmix-rest": "file:../packages/jmix-rest/haulmont-jmix-rest-2.0.0-next.7.tgz",
+    "@haulmont/jmix-react-antd": "file:../packages/jmix-react-antd/haulmont-jmix-react-antd-2.0.0-next.18.tgz",
+    "@haulmont/jmix-react-core": "file:../packages/jmix-react-core/haulmont-jmix-react-core-2.0.0-next.13.tgz",
+    "@haulmont/jmix-react-web": "file:../packages/jmix-react-web/haulmont-jmix-react-web-2.0.0-next.15.tgz",
+    "@haulmont/jmix-rest": "file:../packages/jmix-rest/haulmont-jmix-rest-2.0.0-next.8.tgz",
     "@haulmont/react-ide-toolbox": "^1.0.0",
     "@haulmont/react-scripts": "^1.0.0",
     "antd": "^4.13.0",
@@ -29,7 +29,7 @@
     "update-model": "gen-jmix-front sdk:all --dest src/jmix"
   },
   "devDependencies": {
-    "@haulmont/jmix-front-generator": "file:../packages/jmix-front-generator/haulmont-jmix-front-generator-2.0.0-next.17.tgz",
+    "@haulmont/jmix-front-generator": "file:../packages/jmix-front-generator/haulmont-jmix-front-generator-2.0.0-next.18.tgz",
     "@types/jest": "^27.0.0",
     "@types/node": "^10.12.18",
     "@types/react": "^17.0.2",

--- a/packages/jmix-react-antd/package-lock.json
+++ b/packages/jmix-react-antd/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@haulmont/jmix-react-antd",
-			"version": "2.0.0-next.17",
+			"version": "2.0.0-next.18",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"quill": "^1.3.7",

--- a/packages/jmix-react-antd/src/i18n/I18nProvider.tsx
+++ b/packages/jmix-react-antd/src/i18n/I18nProvider.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback } from 'react';
+import React, {useCallback} from 'react';
 import {observer} from 'mobx-react';
 import {ConfigProvider} from 'antd';
-import {IntlProvider} from 'react-intl';
+import {RawIntlProvider} from 'react-intl';
 import {getMainStore} from '@haulmont/jmix-react-core';
 import {antdLocalesStore} from "./AntdLocalesStore";
 import {localesStore} from "@haulmont/jmix-react-web";
+import {getIntl} from "./intl";
 
 type I18nProviderProps = {
   children: React.ReactNode | React.ReactNode[] | null,
@@ -21,18 +22,20 @@ export const I18nProvider = observer(({children, rtlLayout}: I18nProviderProps) 
     return rtlCondition ? 'rtl' : 'ltr';
   }, [rtlLayout, mainStore?.locale])
 
-  if (!mainStore || !mainStore.locale) {
+  const intl = getIntl();
+
+  if (!mainStore || !mainStore.locale || !intl) {
     return null;
   }
 
   return (
-    <IntlProvider locale={mainStore.locale} messages={localesStore.messagesMapping[mainStore.locale]}>
-      <ConfigProvider 
+    <RawIntlProvider value={intl}>
+      <ConfigProvider
         locale={antdLocalesStore.antdLocaleMapping[mainStore.locale]}
         direction={getDirection()}
       >
         {children}
       </ConfigProvider>
-    </IntlProvider>
+    </RawIntlProvider>
   );
 });

--- a/packages/jmix-react-antd/src/i18n/intl.tsx
+++ b/packages/jmix-react-antd/src/i18n/intl.tsx
@@ -1,0 +1,30 @@
+import {createIntl, createIntlCache, IntlShape} from "react-intl";
+import {getMainStore, onMainStoreCreate} from "@haulmont/jmix-react-core";
+import {localesStore} from "@haulmont/jmix-react-web";
+
+let intl: IntlShape | undefined
+const cache = createIntlCache();
+
+export const getIntl = () => {
+  return intl;
+}
+
+const keepIntlUpdated = () => {
+  onMainStoreCreate((mainStore) => {
+    updateIntl();
+    mainStore.onLocaleChange(updateIntl);
+  })
+}
+
+const updateIntl = () => {
+  const mainStore = getMainStore();
+  if (!mainStore || !mainStore.locale) {
+    return;
+  }
+  intl = createIntl({
+    locale: mainStore.locale,
+    messages: localesStore.messagesMapping[mainStore.locale],
+  }, cache);
+}
+
+keepIntlUpdated();

--- a/packages/jmix-react-antd/src/index.ts
+++ b/packages/jmix-react-antd/src/index.ts
@@ -68,6 +68,7 @@ export * from './ui/FormWizard/FormWizardContext';
 export * from './ui/FormWizard/useEntityEditorFormWizard';
 
 export * from './i18n/I18nProvider';
+export * from './i18n/intl';
 export * from './i18n/AntdLocalesStore';
 
 export * from './ui/Tabs';

--- a/packages/jmix-react-core/package-lock.json
+++ b/packages/jmix-react-core/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@haulmont/jmix-react-core",
-			"version": "2.0.0-next.12",
+			"version": "2.0.0-next.13",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"apollo-upload-client": "^16.0.0",

--- a/packages/jmix-react-core/src/app/JmixAppProvider.tsx
+++ b/packages/jmix-react-core/src/app/JmixAppProvider.tsx
@@ -12,6 +12,7 @@ let jmixAppContext: React.Context<JmixAppContextValue>;
 let jmixAppConfig: JmixAppConfig | undefined;
 let globalJmixREST: JmixRestConnection;
 let mainStore: MainStore;
+const mainStoreCreateListeners : ((mainStore: MainStore) => void)[] = []
 
 export interface JmixAppContextValue {
   jmixREST?: JmixRestConnection;
@@ -24,6 +25,10 @@ export function getJmixREST(): JmixRestConnection | undefined {
 
 export function getMainStore(): MainStore {
   return mainStore;
+}
+
+export function onMainStoreCreate(c: (mainStore: MainStore) => void) {
+  mainStoreCreateListeners.push(c);
 }
 
 export function getJmixAppConfig(): JmixAppConfig | undefined {
@@ -147,6 +152,7 @@ export const JmixAppProvider = ({
             contentDisplayMode,
             graphqlEndpoint
           });
+          mainStoreCreateListeners.forEach((onCreate) => onCreate(mainStore));
           retrieveRestApiToken().then((restApiToken) => {
             if (restApiToken != null) {
               jmixREST.restApiToken = restApiToken;

--- a/packages/jmix-react-core/src/app/MainStore.ts
+++ b/packages/jmix-react-core/src/app/MainStore.ts
@@ -1,4 +1,4 @@
-import { action, autorun, computed, observable, makeObservable } from "mobx";
+import {action, autorun, computed, observable, makeObservable, reaction} from "mobx";
 import {JmixRestConnection, EntityMessages, JmixRestError} from "@haulmont/jmix-rest";
 import {inject, IWrappedComponent, MobXProviderContext} from "mobx-react";
 import {IReactComponent} from "mobx-react/dist/types/IReactComponent";
@@ -65,6 +65,7 @@ export class MainStore {
 
   private tokenExpiryListeners: Array<(() => void)> = [];
   private disposeTokenExpiryListener?: () => void;
+  private localeChangeListeners: Array<((locale: string | null) => void)> = [];
 
   private appName: string;
   private storage: Storage;
@@ -130,6 +131,10 @@ export class MainStore {
       } else {
         this.storage.removeItem(this.localeStorageKey);
       }
+    });
+
+    reaction(() => this.locale, (locale) => {
+      this.localeChangeListeners.forEach((onLocaleChanged) => onLocaleChanged(locale));
     });
   }
 
@@ -302,6 +307,10 @@ export class MainStore {
   onTokenExpiry(c: () => void) {
     this.tokenExpiryListeners.push(c);
     return () => this.tokenExpiryListeners.splice(this.tokenExpiryListeners.indexOf(c), 1);
+  }
+
+  onLocaleChange(c: (locale: string | null) => void) {
+    this.localeChangeListeners.push(c);
   }
 
   /**

--- a/packages/jmix-react-web/package-lock.json
+++ b/packages/jmix-react-web/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@haulmont/jmix-react-web",
-			"version": "2.0.0-next.14",
+			"version": "2.0.0-next.15",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"hotkeys-js": "^3.8.7"

--- a/packages/jmix-rest/package-lock.json
+++ b/packages/jmix-rest/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@haulmont/jmix-rest",
-			"version": "2.0.0-next.7",
+			"version": "2.0.0-next.8",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@typescript-eslint/eslint-plugin": "^4.30.0",


### PR DESCRIPTION
affects: @haulmont/jmix-react-antd, @haulmont/jmix-react-core, @haulmont/jmix-react-web,
@haulmont/jmix-rest