### PR TITLE
fix: enabling field settings in DataTable breaks row selection #919

### DIFF
--- a/packages/jmix-react-ui/src/ui/table/DataTable.tsx
+++ b/packages/jmix-react-ui/src/ui/table/DataTable.tsx
@@ -463,11 +463,13 @@ class DataTableComponent<
   };
 
   renderBodyOnlyVisible = (props: any) => {
-    if (!Array.isArray(props.children)) {
-      return props.children;
+    const { children, ...rowProps } = props;
+
+    if (!Array.isArray(children)) {
+      return children;
     }
 
-    return <tr className={props.className}>
+    return <tr {...rowProps}>
       {props.children.filter((col: any) => this.fieldsVisibility.get(col.key as string))}
     </tr>
   }


### PR DESCRIPTION
affects: @haulmont/jmix-react-ui