### PR TITLE
chore: rename Cuba to Jmix #804

### DIFF
--- a/packages/jmix-front-generator/src/common/studio/studio-integration.ts
+++ b/packages/jmix-front-generator/src/common/studio/studio-integration.ts
@@ -2,7 +2,7 @@ import fetch from 'node-fetch'
 
 const DEFAULT_INTEGRATION_PORT = 48561;
 export const ERR_STUDIO_NOT_CONNECTED = '' +
-  'Can\'t establish connection to CUBA Studio. Please open CUBA Studio Intellij and tick \'Enable Integration\' checkbox. ' +
+  'Can\'t establish connection to Jmix Studio. Please open Jmix plugin settings in Intellij IDEA and select \'Enable Integration\' checkbox. ' +
   'Or provide path to project model json file as cli parameter --model';
 
 export interface StudioProjectInfo {


### PR DESCRIPTION
affects: @haulmont/jmix-front-generator